### PR TITLE
Replace gridstack ES module

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,5 @@
 import { GridStack } from
-  'https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.esm.js';
+  'https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js';
 
 const grid = GridStack.init({ column:12, float:false, resizable:{handles:'e, se, s, w'} }, '#grid');
 grid.on('change', saveLayout);


### PR DESCRIPTION
## Summary
- load non-ESM version of GridStack from CDN

## Testing
- `npm install`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6850549218a48328ad822664a56ab6fa