### PR TITLE
Fix GridStack CDN path

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,5 @@
 import { GridStack } from
-  'https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js';
+  'https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-all.js';
 
 const grid = GridStack.init({ column:12, float:false, resizable:{handles:'e, se, s, w'} }, '#grid');
 grid.on('change', saveLayout);


### PR DESCRIPTION
## Summary
- fix `gridstack-h5.js` 404 by loading `gridstack-all.js` instead

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68505e8ebb0c832887864d0da2324432