### PR TITLE
Fix GridStack import from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack.min.css" rel="stylesheet"/>
   <link rel="stylesheet" href="/src/css/main.css" />
   <link rel="manifest" href="/manifest.json" />
+  <script src="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-all.js"></script>
   <script type="module" src="/src/js/app.js"></script>
 </head>
 <body>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,4 @@
-import { GridStack } from
-  'https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js';
+const { GridStack } = window;
 
 const grid = GridStack.init({ column:12, float:false, resizable:{handles:'e, se, s, w'} }, '#grid');
 grid.on('change', saveLayout);


### PR DESCRIPTION
## Summary
- include GridStack CDN script in `index.html`
- use `window.GridStack` in app

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505e8ebb0c832887864d0da2324432