### PR TITLE
Update GridStack usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ if ("serviceWorker" in navigator) {
 </script>
 ```
 
+## Loading GridStack
+
+Add GridStack from its CDN build:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-all.js"></script>
+```
+
+`app.js` accesses `window.GridStack` directly—this build exposes a global variable only, so there is no ES module to import.


### PR DESCRIPTION
## Summary
- document that GridStack is loaded via CDN
- explain why `window.GridStack` is used

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850666a1c5c8328a409a2597dead63e