### PR TITLE
Implement card component

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ if ("serviceWorker" in navigator) {
 ## Loading GridStack
 
 GridStack is installed via npm and imported as an ES module from `app.js`.
+
+### Passo de teste 4.2
+
+1. Execute `npm run dev` e abra `http://localhost:5173`.
+2. Clique no botão **+** para adicionar um novo card.
+3. Edite o título e o texto. Altere a cor e teste o bloqueio/copiar.
+4. Recarregue a página e confirme que o conteúdo persiste.

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -12,3 +12,7 @@ body{margin:0;font-family:sans-serif}
 .grid-stack-item-content textarea{
   flex:1;border:none;resize:none;font:inherit
 }
+.card-actions{
+  display:flex;gap:.25rem;justify-content:flex-end;margin-bottom:.25rem
+}
+.card-actions button{background:none;border:none;cursor:pointer}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,6 @@
 import { GridStack } from 'gridstack';
 import * as Store from './store.js';
+import { create as createCard } from './ui/card.js';
 
 const grid = GridStack.init(
   { column: 12, float: false, resizable: { handles: 'e, se, s, w' } },
@@ -9,26 +10,25 @@ grid.on('change', saveLayout);
 
 document.getElementById('fab-add').addEventListener('click', addCard);
 
-function addCard(data={x:0,y:0,w:3,h:2,title:'Título',text:''}){
-  const el=document.createElement('div');
-  el.innerHTML=`
-    <div class="grid-stack-item-content">
-      <h6 contenteditable="true">${data.title}</h6>
-      <textarea>${data.text}</textarea>
-    </div>`;
+function addCard(data={x:0,y:0,w:3,h:2}){
+  const el = createCard({});
   grid.addWidget(el,data);
   saveLayout();
 }
 
 function saveLayout() {
-  Store.data.layout = grid.save(true);
+  Store.data.layout = grid.save();
   Store.save();
 }
 
 async function restore() {
   await Store.load();
   if (Store.data.layout && Store.data.layout.length) {
-    grid.load(Store.data.layout).forEach(() => {});
+    grid.removeAll();
+    Store.data.layout.forEach(opts => {
+      const el = createCard(Store.data.items[opts.id] || {});
+      grid.addWidget(el, opts);
+    });
   } else {
     // primeiro uso: 3 cards demo
     addCard({ x: 0, y: 0 });

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -21,6 +21,12 @@ export function upsert(item) {
   return item.id;
 }
 
+export function patch(id, changes) {
+  if (!data.items[id]) return;
+  Object.assign(data.items[id], changes);
+  save();
+}
+
 export function remove(id) {
   delete data.items[id];
   save();

--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -1,0 +1,65 @@
+import * as Store from '../store.js';
+
+export function create(data = {}) {
+  const item = {
+    type: 'card',
+    title: data.title || 'Título',
+    text: data.text || '',
+    color: data.color || '#77d6ec',
+    locked: data.locked || false,
+    id: data.id
+  };
+  const id = Store.upsert(item);
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('gs-id', id);
+  wrapper.innerHTML = `
+    <div class="grid-stack-item-content card">
+      <div class="card-actions">
+        <button class="lock" aria-label="Lock">🔒</button>
+        <button class="copy" aria-label="Copy">📄</button>
+        <input class="color" type="color" value="${item.color}">
+      </div>
+      <h6 contenteditable="true" spellcheck="false"></h6>
+      <textarea></textarea>
+    </div>`;
+  const content = wrapper.firstElementChild;
+  const titleEl = content.querySelector('h6');
+  const textEl = content.querySelector('textarea');
+  const colorEl = content.querySelector('input.color');
+  const lockBtn = content.querySelector('button.lock');
+  titleEl.textContent = item.title;
+  textEl.value = item.text;
+  applyColor(item.color);
+  setLock(item.locked);
+
+  titleEl.addEventListener('input', () => {
+    Store.patch(id, { title: titleEl.textContent });
+  });
+  textEl.addEventListener('input', () => {
+    Store.patch(id, { text: textEl.value });
+  });
+  colorEl.addEventListener('input', () => {
+    applyColor(colorEl.value);
+    Store.patch(id, { color: colorEl.value });
+  });
+  lockBtn.addEventListener('click', () => {
+    setLock(!wrapper.dataset.locked);
+    Store.patch(id, { locked: wrapper.dataset.locked === 'true' });
+  });
+  content.querySelector('button.copy').addEventListener('click', () => {
+    navigator.clipboard.writeText(textEl.value);
+  });
+
+  function applyColor(value) {
+    content.style.background = value;
+  }
+
+  function setLock(flag) {
+    wrapper.dataset.locked = flag;
+    titleEl.contentEditable = !flag;
+    textEl.readOnly = flag;
+    lockBtn.textContent = flag ? '🔓' : '🔒';
+  }
+
+  return wrapper;
+}


### PR DESCRIPTION
## Summary
- create Card component with editable title and text
- persist card changes to the store
- store patch utility to update item fields
- render cards through component in `app.js`
- document manual test for cards

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850783537a48328b5be9970ace4d7d2