### PR TITLE
Add keyboard nav, dark mode, and responsive grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
 </head>
 <body>
   <button id="fab-add" aria-label="Adicionar">+</button>
-  <div class="grid-stack" id="grid"></div>
+  <div class="grid-stack" id="grid" role="list" aria-label="Notas"></div>
 </body>
 </html>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,4 +1,5 @@
 body{margin:0;font-family:sans-serif}
+#grid{display:grid;grid-template-columns:repeat(12,1fr);gap:.5rem}
 #fab-add{
   position:fixed;right:2rem;bottom:2rem;
   width:56px;height:56px;border-radius:50%;
@@ -16,3 +17,17 @@ body{margin:0;font-family:sans-serif}
   display:flex;gap:.25rem;justify-content:flex-end;margin-bottom:.25rem
 }
 .card-actions button{background:none;border:none;cursor:pointer}
+
+@media (max-width:1024px) and (min-width:600px){
+  #grid{grid-template-columns:repeat(6,1fr)}
+}
+
+@media (max-width:600px){
+  #grid{grid-template-columns:repeat(3,1fr)}
+}
+
+@media (prefers-color-scheme: dark){
+  body{background:#121212;color:#fff}
+  #fab-add{background:#0d6efd}
+  .grid-stack-item-content{background:#1e1e1e;border-color:#ffffff33}
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8,6 +8,35 @@ const grid = GridStack.init(
 );
 grid.on('change', saveLayout);
 
+function updateColumns() {
+  const width = window.innerWidth;
+  let cols = 12;
+  if (width < 600) cols = 3;
+  else if (width < 1024) cols = 6;
+  if (grid.opts.column !== cols) grid.column(cols);
+}
+window.addEventListener('resize', updateColumns);
+updateColumns();
+
+document.addEventListener('keydown', navigateCards);
+
+function navigateCards(e){
+  const cards = Array.from(document.querySelectorAll('.grid-stack-item-content'));
+  const idx = cards.indexOf(document.activeElement);
+  if (idx === -1) return;
+  if (['ArrowRight','ArrowDown'].includes(e.key)){
+    const next = cards[idx+1];
+    if (next){ next.focus(); e.preventDefault(); }
+  } else if (['ArrowLeft','ArrowUp'].includes(e.key)){
+    const prev = cards[idx-1];
+    if (prev){ prev.focus(); e.preventDefault(); }
+  } else if (e.key === 'Enter'){
+    const first = document.activeElement.querySelector('h6[contenteditable]') ||
+                  document.activeElement.querySelector('textarea');
+    if (first){ first.focus(); e.preventDefault(); }
+  }
+}
+
 document.getElementById('fab-add').addEventListener('click', addCard);
 
 function addCard(data={x:0,y:0,w:3,h:2}){

--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -13,11 +13,11 @@ export function create(data = {}) {
   const wrapper = document.createElement('div');
   wrapper.setAttribute('gs-id', id);
   wrapper.innerHTML = `
-    <div class="grid-stack-item-content card">
+    <div class="grid-stack-item-content card" tabindex="0" role="listitem" aria-label="Note card">
       <div class="card-actions">
         <button class="lock" aria-label="Lock">🔒</button>
         <button class="copy" aria-label="Copy">📄</button>
-        <input class="color" type="color" value="${item.color}">
+        <input class="color" type="color" aria-label="Color" value="${item.color}">
       </div>
       <h6 contenteditable="true" spellcheck="false"></h6>
       <textarea></textarea>


### PR DESCRIPTION
## Summary
- allow keyboard navigation with arrow/enter keys
- respond to resize events and adapt grid columns
- add dark mode styling and responsive CSS breakpoints
- improve ARIA markup on cards and grid container

## Testing
- `npm run build`
- `npx eslint .` *(fails: couldn't find config)*
- `npx prettier -c .`

------
https://chatgpt.com/codex/tasks/task_e_6850aae258c8832897caf102e0619295