### PR TITLE
Add i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,19 @@ GridStack is installed via npm and imported as an ES module from `app.js`.
 2. Clique no botão **+** para adicionar um novo card.
 3. Edite o título e o texto. Altere a cor e teste o bloqueio/copiar.
 4. Recarregue a página e confirme que o conteúdo persiste.
+
+## Switching languages
+
+The interface defaults to the browser language and supports English (`en`) and Portuguese (`pt`).
+To override the detected language, set the `lang` key in `localStorage` and reload:
+
+```js
+localStorage.setItem('lang', 'en');
+location.reload();
+```
+
+You can also change it at runtime from the console:
+
+```js
+i18n.setLanguage('pt');
+```

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -11,7 +11,7 @@
   <script type="module" src="/src/js/app.js"></script>
 </head>
 <body>
-  <button id="fab-add" aria-label="Adicionar">+</button>
+  <button id="fab-add" aria-label="Add">+</button>
   <div class="grid-stack" id="grid"></div>
 </body>
 </html>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,6 +1,7 @@
 import { GridStack } from 'gridstack';
 import * as Store from './store.js';
 import { create as createCard } from './ui/card.js';
+import { t, getLanguage } from './i18n.js';
 
 const grid = GridStack.init(
   { column: 12, float: false, resizable: { handles: 'e, se, s, w' } },
@@ -8,7 +9,10 @@ const grid = GridStack.init(
 );
 grid.on('change', saveLayout);
 
-document.getElementById('fab-add').addEventListener('click', addCard);
+document.documentElement.lang = getLanguage();
+const addBtn = document.getElementById('fab-add');
+addBtn.setAttribute('aria-label', t('add'));
+addBtn.addEventListener('click', addCard);
 
 function addCard(data={x:0,y:0,w:3,h:2}){
   const el = createCard({});

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -1,0 +1,50 @@
+export const PT = {
+  add: 'Adicionar',
+  lock: 'Bloquear',
+  unlock: 'Desbloquear',
+  copy: 'Copiar',
+  titleDefault: 'Título'
+};
+
+export const EN = {
+  add: 'Add',
+  lock: 'Lock',
+  unlock: 'Unlock',
+  copy: 'Copy',
+  titleDefault: 'Title'
+};
+
+const DICTS = { pt: PT, en: EN };
+let currentLang = 'en';
+
+function detect() {
+  const saved = localStorage.getItem('lang');
+  if (saved && DICTS[saved]) {
+    currentLang = saved;
+  } else if (navigator.language && navigator.language.startsWith('pt')) {
+    currentLang = 'pt';
+  }
+  document.documentElement.lang = currentLang;
+}
+
+detect();
+
+export function setLanguage(lang) {
+  if (DICTS[lang]) {
+    currentLang = lang;
+    localStorage.setItem('lang', lang);
+    document.documentElement.lang = currentLang;
+  }
+}
+
+export function getLanguage() {
+  return currentLang;
+}
+
+export function t(key) {
+  return DICTS[currentLang][key] || key;
+}
+
+if (typeof window !== 'undefined') {
+  window.i18n = { t, setLanguage, getLanguage };
+}

--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -1,9 +1,10 @@
 import * as Store from '../store.js';
+import { t } from '../i18n.js';
 
 export function create(data = {}) {
   const item = {
     type: 'card',
-    title: data.title || 'Título',
+    title: data.title || t('titleDefault'),
     text: data.text || '',
     color: data.color || '#77d6ec',
     locked: data.locked || false,
@@ -15,8 +16,8 @@ export function create(data = {}) {
   wrapper.innerHTML = `
     <div class="grid-stack-item-content card">
       <div class="card-actions">
-        <button class="lock" aria-label="Lock">🔒</button>
-        <button class="copy" aria-label="Copy">📄</button>
+        <button class="lock">🔒</button>
+        <button class="copy">📄</button>
         <input class="color" type="color" value="${item.color}">
       </div>
       <h6 contenteditable="true" spellcheck="false"></h6>
@@ -27,8 +28,11 @@ export function create(data = {}) {
   const textEl = content.querySelector('textarea');
   const colorEl = content.querySelector('input.color');
   const lockBtn = content.querySelector('button.lock');
+  const copyBtn = content.querySelector('button.copy');
   titleEl.textContent = item.title;
   textEl.value = item.text;
+  lockBtn.setAttribute('aria-label', t('lock'));
+  copyBtn.setAttribute('aria-label', t('copy'));
   applyColor(item.color);
   setLock(item.locked);
 
@@ -59,6 +63,7 @@ export function create(data = {}) {
     titleEl.contentEditable = !flag;
     textEl.readOnly = flag;
     lockBtn.textContent = flag ? '🔓' : '🔒';
+    lockBtn.setAttribute('aria-label', flag ? t('unlock') : t('lock'));
   }
 
   return wrapper;


### PR DESCRIPTION
## Summary
- implement an `i18n` module with English and Portuguese strings
- detect language at startup and expose `t()`
- translate card UI and add button label
- mention language switch instructions in the README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850aae2300883289d1d527441f8e6f9