### PR TITLE
Add PWA integration with background sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,22 @@ npm run dev
 
 ## Build
 
-Create a production build in the `dist` folder:
+Create a production build with PWA assets in the `dist` folder:
 
 ```bash
 npm run build
 ```
 
-## Enabling the service worker
+To preview the production build locally:
 
-The service worker located at `src/js/service-worker.js` enables offline support.
-Register it from your application entry or add the snippet below to `index.html`:
-
-```html
-<script>
-if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.register("/src/js/service-worker.js");
-}
-</script>
+```bash
+npm run preview
 ```
+
+## PWA Support
+
+`vite-plugin-pwa` injects the service worker and manifest automatically.
+Offline support is enabled by default and registered from `app.js`.
 
 ## Loading GridStack
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,6 +1,7 @@
 import { GridStack } from 'gridstack';
 import * as Store from './store.js';
 import { create as createCard } from './ui/card.js';
+import { registerDriveSync } from './drive/sync.js';
 
 const grid = GridStack.init(
   { column: 12, float: false, resizable: { handles: 'e, se, s, w' } },
@@ -41,6 +42,7 @@ restore();
 // Register service worker for offline support
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/src/js/service-worker.js');
+    navigator.serviceWorker.register('/service-worker.js');
   });
+  registerDriveSync();
 }

--- a/src/js/drive/sync.js
+++ b/src/js/drive/sync.js
@@ -1,0 +1,7 @@
+export function registerDriveSync() {
+  if ('serviceWorker' in navigator && 'SyncManager' in window) {
+    navigator.serviceWorker.ready
+      .then(sw => sw.sync.register('sync-drive'))
+      .catch(err => console.error('sync registration failed', err));
+  }
+}

--- a/src/js/service-worker.js
+++ b/src/js/service-worker.js
@@ -1,13 +1,8 @@
-const CACHE = 'fastnotes-v1';
-self.addEventListener('install', e => e.waitUntil(
-  caches.open(CACHE).then(cache =>
-    cache.addAll([
-      '/',
-      '/index.html',
-      '/manifest.json'
-    ])
-  )
-));
-self.addEventListener('fetch',e=>{
-  e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request)));
-});
+import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
+import { registerRoute, NavigationRoute } from 'workbox-routing';
+
+precacheAndRoute(self.__WB_MANIFEST);
+
+const handler = createHandlerBoundToURL('/index.html');
+const navigationRoute = new NavigationRoute(handler);
+registerRoute(navigationRoute);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import { VitePWA } from 'vite-plugin-pwa';
+
+export default defineConfig({
+  plugins: [
+    VitePWA({
+      strategies: 'injectManifest',
+      srcDir: 'src/js',
+      filename: 'service-worker.js',
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- configure `vite-plugin-pwa` to inject custom service worker
- add `registerDriveSync` for background sync registration
- register the service worker and sync from `app.js`
- pre-cache static assets and offline fallback with Workbox
- document PWA build and preview steps

## Testing
- `npm install`
- `npm run build`
- `npm run preview` *(fails: manual cancellation after launch)*

------
https://chatgpt.com/codex/tasks/task_e_6850aae0e10c8328b5f93ec80dea0973