### PR TITLE
Add JSON export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,11 @@ GridStack is installed via npm and imported as an ES module from `app.js`.
 2. Clique no botão **+** para adicionar um novo card.
 3. Edite o título e o texto. Altere a cor e teste o bloqueio/copiar.
 4. Recarregue a página e confirme que o conteúdo persiste.
+
+## Backup com JSON
+
+Na interface é possível exportar as notas atuais clicando em **Export**. Um arquivo
+terminado em `.fastnotes.json` será baixado contendo todos os dados.
+
+Para restaurar, clique em **Import** e escolha um arquivo exportado
+anteriormente. A página será recarregada com o conteúdo importado.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   <script type="module" src="/src/js/app.js"></script>
 </head>
 <body>
+  <div id="menu">
+    <button id="btn-export" aria-label="Exportar">Export</button>
+    <button id="btn-import" aria-label="Importar">Import</button>
+    <input type="file" id="import-file" accept=".fastnotes.json" hidden>
+  </div>
   <button id="fab-add" aria-label="Adicionar">+</button>
   <div class="grid-stack" id="grid"></div>
 </body>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,4 +1,6 @@
 body{margin:0;font-family:sans-serif}
+#menu{position:fixed;left:1rem;top:1rem;display:flex;gap:.5rem}
+#menu button{border:none;background:#eee;padding:.25rem .5rem;border-radius:4px;cursor:pointer}
 #fab-add{
   position:fixed;right:2rem;bottom:2rem;
   width:56px;height:56px;border-radius:50%;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,6 +9,15 @@ const grid = GridStack.init(
 grid.on('change', saveLayout);
 
 document.getElementById('fab-add').addEventListener('click', addCard);
+document.getElementById('btn-export').addEventListener('click', Store.exportJSON);
+document.getElementById('btn-import').addEventListener('click', () =>
+  document.getElementById('import-file').click()
+);
+document.getElementById('import-file').addEventListener('change', async e => {
+  if (!e.target.files.length) return;
+  await Store.importJSON(e.target.files[0]);
+  location.reload();
+});
 
 function addCard(data={x:0,y:0,w:3,h:2}){
   const el = createCard({});

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -31,3 +31,21 @@ export function remove(id) {
   delete data.items[id];
   save();
 }
+
+export function exportJSON() {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `fastnotes-${Date.now()}.fastnotes.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export async function importJSON(file) {
+  const text = await file.text();
+  const obj = JSON.parse(text);
+  if (!obj || typeof obj !== 'object') return;
+  data = obj;
+  save();
+}


### PR DESCRIPTION
## Summary
- allow exporting data to `.fastnotes.json`
- allow importing previously exported JSON files
- add Export/Import buttons in the UI
- style the new menu buttons
- document JSON backup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850aadf65888328aea194354f0b82c3