### PR TITLE
Implement cross-group drag and drop

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -16,3 +16,9 @@ body{margin:0;font-family:sans-serif}
   display:flex;gap:.25rem;justify-content:flex-end;margin-bottom:.25rem
 }
 .card-actions button{background:none;border:none;cursor:pointer}
+
+.folder-overlay{
+  position:fixed;inset:0;background:#0008;display:flex;
+  align-items:center;justify-content:center;
+}
+.folder-overlay.hidden{display:none}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,6 +1,28 @@
 import { GridStack } from 'gridstack';
 import * as Store from './store.js';
 import { create as createCard } from './ui/card.js';
+import { create as createContainer } from './ui/container.js';
+import { create as createFolder } from './ui/folder.js';
+
+let dragItem = null;
+
+function attachGridEvents(g) {
+  g.on('dragstart', (_e, el) => {
+    dragItem = {
+      id: el.getAttribute('gs-id'),
+    };
+  });
+
+  g.on('dropped', (_e, prev, node) => {
+    const el = document.querySelector(`[gs-id="${node.id}"]`);
+    if (!el) return;
+    const parentId = g.el.closest('[gs-id]')?.getAttribute('gs-id') || 'root';
+    el.dataset.parent = parentId;
+    Store.setParent(node.id, parentId);
+    Store.save();
+    if (g === grid) saveLayout();
+  });
+}
 
 const grid = GridStack.init(
   { column: 12, float: false, resizable: { handles: 'e, se, s, w' } },
@@ -8,11 +30,27 @@ const grid = GridStack.init(
 );
 grid.on('change', saveLayout);
 
-document.getElementById('fab-add').addEventListener('click', addCard);
+attachGridEvents(grid);
 
-function addCard(data={x:0,y:0,w:3,h:2}){
-  const el = createCard({});
-  grid.addWidget(el,data);
+document.getElementById('fab-add').addEventListener('click', () => addCard());
+
+function addCard(data={x:0,y:0,w:3,h:2}, g=grid, parent='root'){
+  const el = createCard({parent});
+  g.addWidget(el,data);
+  if (g === grid) saveLayout();
+}
+
+function addContainer(data={x:0,y:0,w:6,h:4}) {
+  const { el, grid: sub } = createContainer({});
+  grid.addWidget(el, data);
+  attachGridEvents(sub);
+  saveLayout();
+}
+
+function addFolder(data={x:0,y:0,w:3,h:3}) {
+  const { el, grid: sub } = createFolder({});
+  grid.addWidget(el, data);
+  attachGridEvents(sub);
   saveLayout();
 }
 
@@ -26,8 +64,20 @@ async function restore() {
   if (Store.data.layout && Store.data.layout.length) {
     grid.removeAll();
     Store.data.layout.forEach(opts => {
-      const el = createCard(Store.data.items[opts.id] || {});
-      grid.addWidget(el, opts);
+      const data = Store.data.items[opts.id] || {};
+      let added;
+      if (data.type === 'container') {
+        added = createContainer(data);
+        grid.addWidget(added.el, opts);
+        attachGridEvents(added.grid);
+      } else if (data.type === 'folder') {
+        added = createFolder(data);
+        grid.addWidget(added.el, opts);
+        attachGridEvents(added.grid);
+      } else {
+        const el = createCard(data);
+        grid.addWidget(el, opts);
+      }
     });
   } else {
     // primeiro uso: 3 cards demo

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -16,6 +16,7 @@ export function save() {
 
 export function upsert(item) {
   if (!item.id) item.id = nanoid();
+  if (!item.parent) item.parent = 'root';
   data.items[item.id] = item;
   save();
   return item.id;
@@ -29,5 +30,31 @@ export function patch(id, changes) {
 
 export function remove(id) {
   delete data.items[id];
+  save();
+}
+
+export function setParent(id, parentId) {
+  const item = data.items[id];
+  if (!item) return;
+  const oldParent = item.parent || 'root';
+  if (oldParent === parentId) return;
+
+  // remove from old parent children
+  if (oldParent !== 'root') {
+    const p = data.items[oldParent];
+    if (p && Array.isArray(p.children)) {
+      p.children = p.children.filter(cid => cid !== id);
+    }
+  }
+
+  item.parent = parentId || 'root';
+
+  if (parentId && parentId !== 'root') {
+    const newParent = data.items[parentId] || {};
+    if (!Array.isArray(newParent.children)) newParent.children = [];
+    if (!newParent.children.includes(id)) newParent.children.push(id);
+    data.items[parentId] = newParent;
+  }
+
   save();
 }

--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -7,11 +7,13 @@ export function create(data = {}) {
     text: data.text || '',
     color: data.color || '#77d6ec',
     locked: data.locked || false,
-    id: data.id
+    id: data.id,
+    parent: data.parent || 'root'
   };
   const id = Store.upsert(item);
   const wrapper = document.createElement('div');
   wrapper.setAttribute('gs-id', id);
+  wrapper.dataset.parent = item.parent;
   wrapper.innerHTML = `
     <div class="grid-stack-item-content card">
       <div class="card-actions">

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -1,0 +1,58 @@
+import { GridStack } from 'gridstack';
+import * as Store from '../store.js';
+import { create as createCard } from './card.js';
+
+export function create(data = {}) {
+  const item = {
+    type: 'container',
+    title: data.title || 'Container',
+    children: data.children || [],
+    id: data.id,
+    parent: data.parent || 'root',
+    layout: data.layout || []
+  };
+  const id = Store.upsert(item);
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('gs-id', id);
+  wrapper.dataset.parent = item.parent;
+  wrapper.innerHTML = `
+    <div class="grid-stack-item-content container">
+      <h6 contenteditable="true"></h6>
+      <div class="grid-stack subgrid" id="sub-${id}"></div>
+    </div>`;
+  const content = wrapper.firstElementChild;
+  const titleEl = content.querySelector('h6');
+  const subEl = content.querySelector('.subgrid');
+  titleEl.textContent = item.title;
+  titleEl.addEventListener('input', () => {
+    Store.patch(id, { title: titleEl.textContent });
+  });
+
+  const subgrid = GridStack.init({ column: 12, float: false }, subEl);
+  subgrid.on('change', () => {
+    Store.data.items[id].layout = subgrid.save();
+    Store.save();
+  });
+
+  // restore children
+  if (item.layout.length) {
+    subgrid.removeAll();
+    item.layout.forEach(opts => {
+      const child = Store.data.items[opts.id];
+      if (!child) return;
+      let el;
+      if (child.type === 'card') el = createCard(child);
+      // support nested containers/folders later
+      subgrid.addWidget(el, opts);
+    });
+  } else if (item.children.length) {
+    item.children.forEach(cid => {
+      const child = Store.data.items[cid];
+      if (!child) return;
+      let el = createCard(child);
+      subgrid.addWidget(el, {x:0,y:0,w:3,h:2});
+    });
+  }
+
+  return { el: wrapper, grid: subgrid };
+}

--- a/src/js/ui/folder.js
+++ b/src/js/ui/folder.js
@@ -1,0 +1,58 @@
+import { GridStack } from 'gridstack';
+import * as Store from '../store.js';
+import { create as createCard } from './card.js';
+
+export function create(data = {}) {
+  const item = {
+    type: 'folder',
+    title: data.title || 'Folder',
+    children: data.children || [],
+    id: data.id,
+    parent: data.parent || 'root',
+    layout: data.layout || []
+  };
+  const id = Store.upsert(item);
+
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('gs-id', id);
+  wrapper.dataset.parent = item.parent;
+  wrapper.innerHTML = `<div class="grid-stack-item-content folder">📁 ${item.title}</div>`;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'folder-overlay hidden';
+  overlay.innerHTML = `<div class="grid-stack folder-grid" id="fold-${id}"></div>`;
+  document.body.appendChild(overlay);
+
+  const gridEl = overlay.querySelector('.folder-grid');
+  const grid = GridStack.init({ column: 12, float: false }, gridEl);
+  grid.on('change', () => {
+    Store.data.items[id].layout = grid.save();
+    Store.save();
+  });
+
+  wrapper.addEventListener('click', () => overlay.classList.remove('hidden'));
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) overlay.classList.add('hidden');
+  });
+
+  // restore children
+  if (item.layout.length) {
+    grid.removeAll();
+    item.layout.forEach(opts => {
+      const child = Store.data.items[opts.id];
+      if (!child) return;
+      let el;
+      if (child.type === 'card') el = createCard(child);
+      grid.addWidget(el, opts);
+    });
+  } else if (item.children.length) {
+    item.children.forEach(cid => {
+      const child = Store.data.items[cid];
+      if (!child) return;
+      let el = createCard(child);
+      grid.addWidget(el, {x:0,y:0,w:3,h:2});
+    });
+  }
+
+  return { el: wrapper, grid };
+}


### PR DESCRIPTION
## Summary
- add Container and Folder components with nested grids
- track parent for every item in `store.js`
- update `app.js` to handle dragstart/dropped events and save parent changes
- allow adding containers and folders
- minor CSS for folder overlay

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850aadedf908328ac0422c58908e76d