### PR TITLE
Add collapsible containers with debounced Drive sync

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -40,6 +40,7 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__header{display:flex;align-items:center;gap:.25rem;cursor:pointer}
 .container .collapse__header button{background:none;border:none;cursor:pointer}
 .container .collapse__body{overflow:hidden}
+.container.collapsed .collapse__body{display:none}
 
 
 #fab-menu{

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -4,6 +4,7 @@ import * as DriveSync from './drive/sync.js';
 
 const KEY = 'fastnotes-json';
 export let data = { version: 1, updated: Date.now(), items: {}, layout: [] };
+let syncTimer;
 
 export async function load() {
   const raw = localStorage.getItem(KEY);
@@ -14,7 +15,12 @@ export async function load() {
 export function save() {
   data.updated = Date.now();
   localStorage.setItem(KEY, JSON.stringify(data));
-  sync();
+  scheduleSync();
+}
+
+function scheduleSync() {
+  clearTimeout(syncTimer);
+  syncTimer = setTimeout(sync, 2000);
 }
 
 export function upsert(item) {


### PR DESCRIPTION
## Summary
- make containers collapsible again
- hide collapsed container body with new CSS
- debounce Drive sync calls to reduce traffic

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68516a9f4d18832885110583a2287a64