### PR TITLE
Add folder description editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ GridStack is installed via npm and imported as an ES module from `app.js`.
 
 1. Clique no botão **+** e escolha o 📁 para criar uma pasta.
 2. Clique na pasta para abrir a visualização em tela cheia.
-3. Use **ESC** ou o botão de voltar para fechar o overlay.
+3. Edite o título e a descrição da pasta.
+4. Use **ESC** ou o botão de voltar para fechar o overlay.
+5. Reabra a pasta e confirme que título e descrição foram salvos.
 
 ## Backup com JSON
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -53,6 +53,9 @@ body{margin:0;font-family:sans-serif}
   border:none;background:#007bff;color:#fff;font-size:1.25rem;
 }
 .folder-icon{display:flex;align-items:center;justify-content:center;font-size:2rem;}
+.folder-header{display:flex;align-items:center;gap:.5rem;padding:1rem 1rem 0;}
+.folder-header h6{margin:0;font-size:1.25rem;}
+.folder-header textarea{flex:1;resize:vertical;}
 .folder-overlay{
   position:fixed;inset:0;background:#ffffff;z-index:1000;
   display:flex;flex-direction:column;

--- a/src/js/ui/folder.js
+++ b/src/js/ui/folder.js
@@ -6,6 +6,7 @@ export function create(data = {}) {
   const item = {
     type: 'folder',
     title: data.title || 'Folder',
+    desc: data.desc || '',
     children: data.children || [],
     layout: data.layout || [],
     id: data.id
@@ -22,11 +23,27 @@ export function create(data = {}) {
     const overlay = document.createElement('div');
     overlay.className = 'folder-overlay';
     overlay.innerHTML = `
-      <button class="folder-back" aria-label="Back">\u2190</button>
+      <div class="folder-header">
+        <button class="folder-back" aria-label="Back">\u2190</button>
+        <h6 class="folder-title" contenteditable="true"></h6>
+        <textarea class="folder-desc" rows="2"></textarea>
+      </div>
       <div class="grid-stack folder-grid"></div>
     `;
     document.body.appendChild(overlay);
+    const titleEl = overlay.querySelector('.folder-title');
+    const descEl = overlay.querySelector('.folder-desc');
     const gridEl = overlay.querySelector('.folder-grid');
+    titleEl.textContent = item.title;
+    descEl.value = item.desc;
+    titleEl.addEventListener('input', () => {
+      item.title = titleEl.textContent;
+      Store.patch(id, { title: item.title });
+    });
+    descEl.addEventListener('input', () => {
+      item.desc = descEl.value;
+      Store.patch(id, { desc: item.desc });
+    });
     const childGrid = GridStack.init({ column: 12, float: false, resizable:{ handles:'e, se, s, w' } }, gridEl);
 
     if (item.layout && item.layout.length) {


### PR DESCRIPTION
## Summary
- allow folders to store and edit a description
- show folder title and description in overlay
- style folder header
- document folder description in the README test steps

## Testing
- `npm test` *(fails: Missing script)*
- `npx vite build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685171a1098883289b200c0d1135e79e