### PR TITLE
Fix folder interactions and data persistence

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -33,6 +33,9 @@ body{margin:0;font-family:sans-serif}
 .grid-stack-item-content textarea{
   flex:1;border:none;resize:none;font:inherit
 }
+.grid-stack-item-content[data-locked="true"] textarea{
+  background:#f0f0f0;
+}
 .card-actions{
   display:flex;gap:.25rem;justify-content:flex-end;margin-bottom:.25rem
 }
@@ -90,6 +93,7 @@ body{margin:0;font-family:sans-serif}
   body{background:#121212;color:#fff}
   #fab{background:#0d6efd}
   .grid-stack-item-content{background:#1e1e1e;border-color:#ffffff33}
+  .grid-stack-item-content[data-locked="true"] textarea{background:#333}
 }
 
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -27,7 +27,7 @@ function attachGridEvents(g) {
 }
 
 const grid = GridStack.init(
-  { column: 12, float: false, resizable: { handles: 'e, se, s, w' }, acceptWidgets: true },
+  { column: 12, float: false, resizable: { handles: 'e, se, s, w' }, acceptWidgets: true, dragOut: true },
   '#grid'
 );
 grid.on('change', saveLayout);
@@ -156,7 +156,7 @@ async function restore() {
         grid.addWidget(el, opts);
       }
     });
-  } else {
+  } else if (!localStorage.getItem('fastnotes-json')) {
     addCard({ x: 0, y: 0 });
     addCard({ x: 3, y: 0 });
     addCard({ x: 6, y: 0 });

--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -46,10 +46,12 @@ export function create(data = {}) {
   textEl.addEventListener('input', () => {
     Store.patch(id, { text: textEl.value });
   });
-  colorEl.addEventListener('input', () => {
+  function onColorChange() {
     applyColor(colorEl.value);
     Store.patch(id, { color: colorEl.value });
-  });
+  }
+  colorEl.addEventListener('input', onColorChange);
+  colorEl.addEventListener('change', onColorChange);
   lockBtn.addEventListener('click', () => {
     const locked = wrapper.dataset.locked === 'true';
     setLock(!locked);
@@ -72,6 +74,7 @@ export function create(data = {}) {
     wrapper.dataset.locked = flag;
     titleEl.contentEditable = !flag;
     textEl.readOnly = flag;
+    textEl.style.opacity = flag ? '0.6' : '';
     lockBtn.textContent = flag ? '🔓' : '🔒';
     lockBtn.setAttribute('aria-label', flag ? t('unlock') : t('lock'));
   }

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -36,7 +36,7 @@ export function create(data = {}) {
     Store.patch(id, { title: titleEl.textContent });
   });
 
-  const subgrid = GridStack.init({ column: 12, float: false, acceptWidgets: true }, subEl);
+  const subgrid = GridStack.init({ column: 12, float: false, acceptWidgets: true, dragOut: true }, subEl);
   subgrid.on('change', () => {
     item.layout = subgrid.save();
     Store.patch(id, { layout: item.layout });

--- a/src/js/ui/folder.js
+++ b/src/js/ui/folder.js
@@ -20,6 +20,7 @@ export function create(data = {}) {
   icon.addEventListener('click', openFolder);
 
   function openFolder() {
+    if (document.querySelector('.folder-overlay')) return;
     const overlay = document.createElement('div');
     overlay.className = 'folder-overlay';
     overlay.innerHTML = `
@@ -44,7 +45,8 @@ export function create(data = {}) {
       item.desc = descEl.value;
       Store.patch(id, { desc: item.desc });
     });
-    const childGrid = GridStack.init({ column: 12, float: false, resizable:{ handles:'e, se, s, w' }, acceptWidgets: true }, gridEl);
+    const childGrid = GridStack.init({ column: 12, float: false, resizable:{ handles:'e, se, s, w' }, acceptWidgets: true, dragOut: true }, gridEl);
+    if (!childGrid) return;
 
     if (item.layout && item.layout.length) {
       item.layout.forEach(opts => {


### PR DESCRIPTION
## Summary
- allow dragging cards in/out of containers and folders
- improve folder overlay creation
- keep grid empty after deleting all notes
- persist card color reliably
- visually dim locked text areas

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685183589ec48328a1ebd690ac62426b