### PR TITLE
Improve container layout

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -44,7 +44,11 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__header{display:flex;align-items:center;gap:.25rem}
 .container .collapse__header h6{flex:1}
 .container .collapse__header button{background:none;border:none;cursor:pointer}
-.container .collapse__body{overflow:hidden}
+.container .collapse__body{overflow-y:auto;overflow-x:hidden}
+.container .collapse__body::-webkit-scrollbar{width:8px}
+.container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
+.container .subgrid{min-height:100px}
+.container.collapsed{min-height:100px}
 .container.collapsed .collapse__body{display:none}
 
 

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -41,6 +41,16 @@ export function create(data = {}) {
   });
 
   const subgrid = GridStack.init({ column: 12, float: false, acceptWidgets: true, dragOut: true }, subEl);
+  function updateColumns() {
+    const width = subEl.clientWidth;
+    let cols = 12;
+    if (width < 600) cols = 3;
+    else if (width < 1024) cols = 6;
+    if (subgrid.opts.column !== cols) subgrid.column(cols);
+  }
+  const ro = new ResizeObserver(updateColumns);
+  ro.observe(subEl);
+  updateColumns();
   subgrid.on('change', () => {
     item.layout = subgrid.save();
     Store.patch(id, { layout: item.layout });
@@ -78,6 +88,7 @@ export function create(data = {}) {
 
   function setCollapsed(flag) {
     bodyEl.style.display = flag ? 'none' : '';
+    content.style.minHeight = flag ? '100px' : '';
     toggleBtn.textContent = flag ? '▸' : '▾';
     item.collapsed = flag;
     content.classList.toggle('collapsed', flag);


### PR DESCRIPTION
## Summary
- improve container style with scrollbar and min-height
- adapt container grid columns on resize
- ensure collapsed containers remain visible

## Testing
- `npm install`
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851a85f5ae4832884edf2f351a38ce2