### PR TITLE
Fix container collapse and drag issues

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -49,8 +49,15 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__body::-webkit-scrollbar{width:8px}
 .container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
 .container .subgrid{min-height:100px}
-.container.collapsed{min-height:100px;overflow:hidden}
+.container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}
+.container.collapsed::after{
+  content:'\1f512';
+  position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
+  font-size:2rem;opacity:.6;background:rgba(0,0,0,.05);
+  animation:fadeIn .3s;
+}
+@keyframes fadeIn{from{opacity:0}to{opacity:.6}}
 
 
 #fab-menu{

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -89,9 +89,10 @@ function addCard(data = { x: 0, y: 0, w: 3, h: 2 }, g = grid, parent = 'root') {
 }
 
 function addContainer(data = { x: 0, y: 0, w: 6, h: 4 }) {
-  const { el, grid: sub } = createContainer({});
-  grid.addWidget(el, data);
-  attachGridEvents(sub);
+  const added = createContainer({});
+  grid.addWidget(added.el, data);
+  attachGridEvents(added.grid);
+  added.adjust();
   saveLayout();
 }
 
@@ -146,6 +147,7 @@ async function restore() {
         added = createContainer(data);
         grid.addWidget(added.el, opts);
         attachGridEvents(added.grid);
+        added.adjust();
       } else if (data.type === 'folder') {
         const el = createFolder(data);
         grid.addWidget(el, opts);

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -40,12 +40,18 @@ export function create(data = {}) {
     Store.patch(id, { title: titleEl.textContent });
   });
 
-  const subgrid = GridStack.init({ column: 12, float: false, acceptWidgets: true, dragOut: true }, subEl);
+  const subgrid = GridStack.init({
+    column: 12,
+    float: false,
+    acceptWidgets: true,
+    dragOut: true,
+    subGrid: true
+  }, subEl);
   function updateColumns() {
     const width = subEl.clientWidth;
-    let cols = 12;
-    if (width < 600) cols = 3;
-    else if (width < 1024) cols = 6;
+    let cols = Math.floor(width / 150);
+    if (cols < 1) cols = 1;
+    if (cols > 12) cols = 12;
     if (subgrid.opts.column !== cols) subgrid.column(cols);
     adjustHeight();
   }
@@ -113,8 +119,8 @@ export function create(data = {}) {
     parentGrid.save();
   }
 
+  // initialize state after caller inserts element into the grid
   setCollapsed(item.collapsed);
-  setTimeout(adjustHeight);
 
-  return { el: wrapper, grid: subgrid };
+  return { el: wrapper, grid: subgrid, adjust: adjustHeight, setCollapsed };
 }


### PR DESCRIPTION
## Summary
- tweak GridStack options for container subgrids
- use dynamic column count to avoid flattening cards
- expose `adjust()` helper to fix initial height
- ensure container height restored after reload
- add lock overlay to collapsed containers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851c342d0288328a05d86f064397668