### PR TITLE
Fix flattened container card issue

### DIFF
--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -53,7 +53,7 @@ export function create(data = {}) {
     const cellW = parentGrid.cellWidth();
     const width = subEl.clientWidth;
     let cols = Math.round(width / cellW);
-    if (cols < 1) cols = 1;
+    if (cols < 3) cols = 3;
     if (cols > 12) cols = 12;
     if (subgrid.opts.column !== cols) subgrid.column(cols);
     adjustHeight();


### PR DESCRIPTION
## Summary
- ensure container subgrids have a minimum of 3 columns

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851cc6b4f10832893dd98c3630e0942