### PR TITLE
Fix container width handling

### DIFF
--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -53,7 +53,7 @@ export function create(data = {}) {
     const cellW = parentGrid.cellWidth();
     const width = subEl.clientWidth;
     let cols = Math.round(width / cellW);
-    if (cols < 3) cols = 3;
+    if (cols < 1) cols = 1;
     if (cols > 12) cols = 12;
     if (subgrid.opts.column !== cols) subgrid.column(cols);
     adjustHeight();


### PR DESCRIPTION
## Summary
- fix containers flattening cards at small widths by letting subgrids shrink to 1 column

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d51ab4108328bdd858f9dfa19064