### PR TITLE
Fix card flattening

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -29,6 +29,10 @@ body{margin:0;font-family:sans-serif}
   background:#fff;border:2px solid #00000020;border-radius:8px;
   display:flex;flex-direction:column;padding:.5rem
 }
+.grid-stack>.grid-stack-item>.grid-stack-item-content{
+  width:100%;
+  height:100%;
+}
 .grid-stack-item-content h6{margin:0 0 .25rem;font-size:1rem}
 .grid-stack-item-content textarea{
   flex:1;border:none;resize:none;font:inherit


### PR DESCRIPTION
## Summary
- ensure gridstack card contents take up the entire widget space

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d9452c588328bc1d494ca6d17008