### PR TITLE
Fix card layout and restore margins

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -30,8 +30,6 @@ body{margin:0;font-family:sans-serif}
   display:flex;flex-direction:column;padding:.5rem
 }
 .grid-stack>.grid-stack-item>.grid-stack-item-content{
-  width:100%;
-  height:100%;
   box-sizing:border-box;
 }
 .grid-stack-item-content h6{margin:0 0 .25rem;font-size:1rem}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -27,7 +27,7 @@ function attachGridEvents(g) {
 }
 
 const grid = GridStack.init(
-  { column: 12, float: false, resizable: { handles: 'e, se, s, w' }, acceptWidgets: true, dragOut: true },
+  { margin: 8, column: 12, float: false, resizable: { handles: 'e, se, s, w' }, acceptWidgets: true, dragOut: true },
   '#grid'
 );
 grid.on('change', saveLayout);

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -41,6 +41,7 @@ export function create(data = {}) {
   });
 
   const subgrid = GridStack.init({
+    margin: 8,
     column: 12,
     float: false,
     acceptWidgets: true,


### PR DESCRIPTION
## Summary
- restore gridstack margin styles by removing width/height override
- set consistent margin for main grid and containers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851eec314b08328a4fa335512343897