### PR TITLE
Localize container UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Create a production build with PWA assets in the `dist` folder:
 npm run build
 ```
 
-
 To preview the production build locally:
 Copy the contents of `dist/` to a static host such as GitHub Pages or Netlify.
 If the app is served from a subpath (for example
@@ -42,7 +41,6 @@ If the app is served from a subpath (for example
 npm run preview
 ```
 
-
 ## PWA Support
 
 `vite-plugin-pwa` injects the service worker and manifest automatically.
@@ -50,11 +48,9 @@ Offline support is enabled by default and registered from `app.js`.
 
 =======
 
-
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
-=======
+# This project is licensed under the [MIT License](LICENSE).
 
 ## Loading GridStack
 
@@ -67,14 +63,12 @@ GridStack is installed via npm and imported as an ES module from `app.js`.
 3. Edite o título e o texto. Altere a cor e teste o bloqueio/copiar.
 4. Recarregue a página e confirme que o conteúdo persiste.
 
-
 ### Passo de teste 4.4
 
 1. Execute `npm run dev` e abra `http://localhost:5173`.
 2. Clique no **+** e escolha **Container**.
 3. Use a seta para recolher e expandir. Arraste o container pelo grid.
 4. Recarregue a página e confirme que o container continua no lugar.
-
 
 ### Passo de teste 4.5
 
@@ -92,7 +86,6 @@ terminado em `.fastnotes.json` será baixado contendo todos os dados.
 Para restaurar, clique em **Import** e escolha um arquivo exportado
 anteriormente. A página será recarregada com o conteúdo importado.
 
-
 ### Passo de teste 4.9
 
 1. Clique em **Login** e autorize o acesso ao Google Drive.
@@ -106,16 +99,14 @@ The interface defaults to the browser language and supports English (`en`) and P
 To override the detected language, set the `lang` key in `localStorage` and reload:
 
 ```js
-localStorage.setItem('lang', 'en');
+localStorage.setItem("lang", "en");
 location.reload();
 ```
 
 You can also change it at runtime from the console:
 
 ```js
-i18n.setLanguage('pt');
+i18n.setLanguage("pt");
 ```
 
-
-
-
+Container buttons and the default container title now use translation keys.

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -1,28 +1,36 @@
 export const PT = {
-  add: 'Adicionar',
-  lock: 'Bloquear',
-  unlock: 'Desbloquear',
-  copy: 'Copiar',
-  titleDefault: 'Título'
+  add: "Adicionar",
+  lock: "Bloquear",
+  unlock: "Desbloquear",
+  copy: "Copiar",
+  titleDefault: "Título",
+  containerDefault: "Container",
+  toggle: "Alternar",
+  addCard: "Adicionar card",
+  delete: "Excluir",
 };
 
 export const EN = {
-  add: 'Add',
-  lock: 'Lock',
-  unlock: 'Unlock',
-  copy: 'Copy',
-  titleDefault: 'Title'
+  add: "Add",
+  lock: "Lock",
+  unlock: "Unlock",
+  copy: "Copy",
+  titleDefault: "Title",
+  containerDefault: "Container",
+  toggle: "Toggle",
+  addCard: "Add card",
+  delete: "Delete",
 };
 
 const DICTS = { pt: PT, en: EN };
-let currentLang = 'en';
+let currentLang = "en";
 
 function detect() {
-  const saved = localStorage.getItem('lang');
+  const saved = localStorage.getItem("lang");
   if (saved && DICTS[saved]) {
     currentLang = saved;
-  } else if (navigator.language && navigator.language.startsWith('pt')) {
-    currentLang = 'pt';
+  } else if (navigator.language && navigator.language.startsWith("pt")) {
+    currentLang = "pt";
   }
   document.documentElement.lang = currentLang;
 }
@@ -32,7 +40,7 @@ detect();
 export function setLanguage(lang) {
   if (DICTS[lang]) {
     currentLang = lang;
-    localStorage.setItem('lang', lang);
+    localStorage.setItem("lang", lang);
     document.documentElement.lang = currentLang;
   }
 }
@@ -45,6 +53,6 @@ export function t(key) {
   return DICTS[currentLang][key] || key;
 }
 
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   window.i18n = { t, setLanguage, getLanguage };
 }

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -1,20 +1,21 @@
-import { GridStack } from 'gridstack';
-import * as Store from '../store.js';
-import { create as createCard } from './card.js';
+import { GridStack } from "gridstack";
+import * as Store from "../store.js";
+import { create as createCard } from "./card.js";
+import { t } from "../i18n.js";
 
 export function create(data = {}) {
   const item = {
-    type: 'container',
-    title: data.title || 'Container',
+    type: "container",
+    title: data.title || t("containerDefault"),
     children: data.children || [],
     layout: data.layout || [],
     collapsed: data.collapsed || false,
     id: data.id,
-    parent: data.parent || 'root'
+    parent: data.parent || "root",
   };
   const id = Store.upsert(item);
-  const wrapper = document.createElement('div');
-  wrapper.setAttribute('gs-id', id);
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("gs-id", id);
   wrapper.dataset.parent = item.parent;
   wrapper.innerHTML = `
     <div class="grid-stack-item-content container">
@@ -29,27 +30,33 @@ export function create(data = {}) {
       </div>
     </div>`;
   const content = wrapper.firstElementChild;
-  const titleEl = content.querySelector('h6');
-  const toggleBtn = content.querySelector('button.toggle');
-  const addBtn = content.querySelector('button.add-card');
-  const delBtn = content.querySelector('button.delete');
-  const bodyEl = content.querySelector('.collapse__body');
-  const subEl = content.querySelector('.subgrid');
+  const titleEl = content.querySelector("h6");
+  const toggleBtn = content.querySelector("button.toggle");
+  const addBtn = content.querySelector("button.add-card");
+  const delBtn = content.querySelector("button.delete");
+  const bodyEl = content.querySelector(".collapse__body");
+  const subEl = content.querySelector(".subgrid");
+  toggleBtn.setAttribute("aria-label", t("toggle"));
+  addBtn.setAttribute("aria-label", t("addCard"));
+  delBtn.setAttribute("aria-label", t("delete"));
   titleEl.textContent = item.title;
-  titleEl.addEventListener('input', () => {
+  titleEl.addEventListener("input", () => {
     Store.patch(id, { title: titleEl.textContent });
   });
 
-  const subgrid = GridStack.init({
-    margin: 8,
-    column: 12,
-    float: false,
-    acceptWidgets: true,
-    dragOut: true,
-    subGrid: true
-  }, subEl);
+  const subgrid = GridStack.init(
+    {
+      margin: 8,
+      column: 12,
+      float: false,
+      acceptWidgets: true,
+      dragOut: true,
+      subGrid: true,
+    },
+    subEl,
+  );
   function updateColumns() {
-    const parentGrid = wrapper.closest('.grid-stack')?.gridstack;
+    const parentGrid = wrapper.closest(".grid-stack")?.gridstack;
     if (!parentGrid) return;
     const cellW = parentGrid.cellWidth();
     const width = subEl.clientWidth;
@@ -66,18 +73,18 @@ export function create(data = {}) {
     restoreChildren();
     adjustHeight();
   });
-  subgrid.on('change', () => {
+  subgrid.on("change", () => {
     item.layout = subgrid.save();
     Store.patch(id, { layout: item.layout });
   });
 
-  addBtn.addEventListener('click', () => {
+  addBtn.addEventListener("click", () => {
     const el = createCard({ parent: id });
     subgrid.addWidget(el, { x: 0, y: 0, w: 3, h: 2 });
   });
 
-  delBtn.addEventListener('click', () => {
-    const g = wrapper.closest('.grid-stack')?.gridstack;
+  delBtn.addEventListener("click", () => {
+    const g = wrapper.closest(".grid-stack")?.gridstack;
     if (g) g.removeWidget(wrapper);
     Store.remove(id);
   });
@@ -85,15 +92,15 @@ export function create(data = {}) {
   function restoreChildren() {
     if (item.layout.length) {
       subgrid.removeAll();
-      item.layout.forEach(opts => {
+      item.layout.forEach((opts) => {
         const child = Store.data.items[opts.id];
         if (!child) return;
         let el;
-        if (child.type === 'card') el = createCard(child);
+        if (child.type === "card") el = createCard(child);
         if (el) subgrid.addWidget(el, opts);
       });
     } else if (item.children.length) {
-      item.children.forEach(cid => {
+      item.children.forEach((cid) => {
         const child = Store.data.items[cid];
         if (!child) return;
         const el = createCard(child);
@@ -103,19 +110,19 @@ export function create(data = {}) {
   }
 
   function setCollapsed(flag) {
-    bodyEl.style.display = flag ? 'none' : '';
-    content.style.minHeight = flag ? '100px' : '';
-    toggleBtn.textContent = flag ? '▸' : '▾';
+    bodyEl.style.display = flag ? "none" : "";
+    content.style.minHeight = flag ? "100px" : "";
+    toggleBtn.textContent = flag ? "▸" : "▾";
     item.collapsed = flag;
-    content.classList.toggle('collapsed', flag);
+    content.classList.toggle("collapsed", flag);
     Store.patch(id, { collapsed: flag });
     setTimeout(adjustHeight, 300);
   }
 
-  toggleBtn.addEventListener('click', () => setCollapsed(!item.collapsed));
+  toggleBtn.addEventListener("click", () => setCollapsed(!item.collapsed));
 
   function adjustHeight() {
-    const parentGrid = wrapper.closest('.grid-stack')?.gridstack;
+    const parentGrid = wrapper.closest(".grid-stack")?.gridstack;
     if (!parentGrid) return;
     const cellH = parentGrid.getCellHeight();
     const newH = Math.max(1, Math.ceil(content.offsetHeight / cellH));


### PR DESCRIPTION
## Summary
- import `t` helper in container UI
- translate container default title and button labels
- add strings to the language dictionaries
- note the UI change in the README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851f74984488328b0bdb6a0f7afbc0a