### PR TITLE
Implement native grid container

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <button id="fab-main" aria-label="Adicionar" class="fab-main">+</button>
     <button id="fab-card" class="fab-option" aria-label="Novo card">📄</button>
     <button id="fab-container" class="fab-option" aria-label="Novo container">📦</button>
+    <button id="fab-container-native" class="fab-option" aria-label="Novo container nativo">🧩</button>
     <button id="fab-folder" class="fab-option" aria-label="Nova pasta">📁</button>
   </div>
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -52,6 +52,12 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__body::-webkit-scrollbar{width:8px}
 .container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
 .container .subgrid{min-height:100px}
+.container .native-grid{
+  display:grid;
+  gap:8px;
+  grid-template-columns:repeat(var(--cols,3),1fr);
+  min-height:100px
+}
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}
 .container.collapsed::after{

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,6 +2,7 @@ import { GridStack } from 'gridstack';
 import * as Store from './store.js';
 import { create as createCard } from './ui/card.js';
 import { create as createContainer } from './ui/container.js';
+import { create as createNativeContainer } from './ui/container-native.js';
 import { create as createFolder } from './ui/folder.js';
 import { registerDriveSync } from './drive/sync.js';
 import * as Auth from './drive/auth.js';
@@ -38,11 +39,13 @@ const fab = document.getElementById('fab');
 const fabMain = document.getElementById('fab-main');
 const fabCard = document.getElementById('fab-card');
 const fabContainerBtn = document.getElementById('fab-container');
+const fabContainerNativeBtn = document.getElementById('fab-container-native');
 const fabFolderBtn = document.getElementById('fab-folder');
 
 fabMain.addEventListener('click', toggleMenu);
 fabCard.addEventListener('click', () => { addCard(); toggleMenu(false); });
 fabContainerBtn.addEventListener('click', () => { addContainer(); toggleMenu(false); });
+fabContainerNativeBtn.addEventListener('click', () => { addNativeContainer(); toggleMenu(false); });
 fabFolderBtn.addEventListener('click', () => { addFolder(); toggleMenu(false); });
 document.addEventListener('keydown', e => { if (e.key === 'Escape') toggleMenu(false); });
 
@@ -78,7 +81,7 @@ authBtn.addEventListener('click', async () => {
 function toggleMenu(force) {
   const open = typeof force === 'boolean' ? force : !fab.classList.contains('open');
   fab.classList.toggle('open', open);
-  [fabCard, fabContainerBtn, fabFolderBtn].forEach(btn => btn.disabled = !open);
+  [fabCard, fabContainerBtn, fabContainerNativeBtn, fabFolderBtn].forEach(btn => btn.disabled = !open);
   if (open) fabCard.focus();
 }
 
@@ -92,6 +95,13 @@ function addContainer(data = { x: 0, y: 0, w: 6, h: 4 }) {
   const added = createContainer({});
   grid.addWidget(added.el, data);
   attachGridEvents(added.grid);
+  added.adjust();
+  saveLayout();
+}
+
+function addNativeContainer(data = { x: 0, y: 0, w: 6, h: 4 }) {
+  const added = createNativeContainer({});
+  grid.addWidget(added.el, data);
   added.adjust();
   saveLayout();
 }
@@ -147,6 +157,10 @@ async function restore() {
         added = createContainer(data);
         grid.addWidget(added.el, opts);
         attachGridEvents(added.grid);
+        added.adjust();
+      } else if (data.type === 'container-native') {
+        added = createNativeContainer(data);
+        grid.addWidget(added.el, opts);
         added.adjust();
       } else if (data.type === 'folder') {
         const el = createFolder(data);

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -1,0 +1,121 @@
+import * as Store from "../store.js";
+import { create as createCard } from "./card.js";
+import { t } from "../i18n.js";
+
+export function create(data = {}) {
+  const item = {
+    type: "container-native",
+    title: data.title || t("containerDefault"),
+    children: data.children || [],
+    collapsed: data.collapsed || false,
+    id: data.id,
+    parent: data.parent || "root",
+  };
+  const id = Store.upsert(item);
+
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("gs-id", id);
+  wrapper.dataset.parent = item.parent;
+  wrapper.innerHTML = `
+    <div class="grid-stack-item-content container">
+      <div class="collapse__header">
+        <button class="toggle" aria-label="Toggle">▾</button>
+        <h6 contenteditable="true"></h6>
+        <button class="add-card" aria-label="Add card">+</button>
+        <button class="delete" aria-label="Delete">🗑️</button>
+      </div>
+      <div class="collapse__body native-grid"></div>
+    </div>`;
+
+  const content = wrapper.firstElementChild;
+  const titleEl = content.querySelector("h6");
+  const toggleBtn = content.querySelector("button.toggle");
+  const addBtn = content.querySelector("button.add-card");
+  const delBtn = content.querySelector("button.delete");
+  const bodyEl = content.querySelector(".collapse__body");
+  const gridEl = content.querySelector(".native-grid");
+
+  toggleBtn.setAttribute("aria-label", t("toggle"));
+  addBtn.setAttribute("aria-label", t("addCard"));
+  delBtn.setAttribute("aria-label", t("delete"));
+
+  titleEl.textContent = item.title;
+  titleEl.addEventListener("input", () => {
+    Store.patch(id, { title: titleEl.textContent });
+  });
+
+  function updateColumns() {
+    const parentGrid = wrapper.closest(".grid-stack")?.gridstack;
+    if (!parentGrid) return;
+    if (bodyEl.style.display === "none") return;
+    const cellW = parentGrid.cellWidth();
+    const width = gridEl.clientWidth;
+    let cols = Math.round(width / cellW);
+    cols = Math.max(1, Math.min(12, cols));
+    gridEl.style.setProperty("--cols", cols);
+    adjustHeight();
+  }
+
+  const ro = new ResizeObserver(updateColumns);
+  ro.observe(gridEl);
+  setTimeout(() => {
+    updateColumns();
+    restoreChildren();
+    adjustHeight();
+  });
+
+  addBtn.addEventListener("click", () => {
+    const el = createCard({ parent: id });
+    gridEl.appendChild(el);
+    item.children.push(el.getAttribute("gs-id"));
+    Store.patch(id, { children: item.children });
+    adjustHeight();
+  });
+
+  delBtn.addEventListener("click", () => {
+    const g = wrapper.closest(".grid-stack")?.gridstack;
+    if (g) g.removeWidget(wrapper);
+    Store.remove(id);
+  });
+
+  function restoreChildren() {
+    if (item.children.length) {
+      gridEl.innerHTML = "";
+      item.children.forEach((cid) => {
+        const child = Store.data.items[cid];
+        if (!child) return;
+        const el = createCard(child);
+        gridEl.appendChild(el);
+      });
+    }
+  }
+
+  function setCollapsed(flag) {
+    bodyEl.style.display = flag ? "none" : "";
+    content.style.minHeight = flag ? "100px" : "";
+    toggleBtn.textContent = flag ? "▸" : "▾";
+    item.collapsed = flag;
+    content.classList.toggle("collapsed", flag);
+    Store.patch(id, { collapsed: flag });
+    setTimeout(() => {
+      adjustHeight();
+      if (!flag) updateColumns();
+    }, 300);
+  }
+
+  toggleBtn.addEventListener("click", () => setCollapsed(!item.collapsed));
+
+  function adjustHeight() {
+    const parentGrid = wrapper.closest(".grid-stack")?.gridstack;
+    if (!parentGrid) return;
+    const cellH = parentGrid.getCellHeight();
+    const newH = Math.max(1, Math.ceil(content.offsetHeight / cellH));
+    parentGrid.update(wrapper, { h: newH });
+    parentGrid.save();
+  }
+
+  setCollapsed(item.collapsed);
+
+  return { el: wrapper, adjust: adjustHeight, setCollapsed };
+}
+


### PR DESCRIPTION
## Summary
- add a "native container" button in `index.html`
- support native-grid layout in CSS
- implement `container-native.js` using CSS Grid
- wire new container type in `app.js`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852d019c730832891a9504a560af6d3