### PR TITLE
Use native grid inside containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Offline support is enabled by default and registered from `app.js`.
 ## Loading GridStack
 
 GridStack is installed via npm and imported as an ES module from `app.js`.
+Containers no longer use a nested GridStack instance. Instead, their internal
+layout relies on a native CSS Grid controlled with JavaScript.
 
 ### Passo de teste 4.2
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -94,7 +94,6 @@ function addCard(data = { x: 0, y: 0, w: 3, h: 2 }, g = grid, parent = 'root') {
 function addContainer(data = { x: 0, y: 0, w: 6, h: 4 }) {
   const added = createContainer({});
   grid.addWidget(added.el, data);
-  attachGridEvents(added.grid);
   added.adjust();
   saveLayout();
 }
@@ -156,7 +155,6 @@ async function restore() {
       if (data.type === 'container') {
         added = createContainer(data);
         grid.addWidget(added.el, opts);
-        attachGridEvents(added.grid);
         added.adjust();
       } else if (data.type === 'container-native') {
         added = createNativeContainer(data);


### PR DESCRIPTION
## Summary
- switch container.js to a CSS grid implementation
- remove nested GridStack logic from app.js
- document that containers now rely on a native CSS Grid

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852e8b64844832894c6f0118b984ddf