### PR TITLE
Enable resizable cards inside containers

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -61,6 +61,7 @@ body{margin:0;font-family:sans-serif}
   display:grid;
   gap:8px;
   grid-template-columns:repeat(var(--cols,3),1fr);
+  grid-auto-rows:100px;
   min-height:100px
 }
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -53,6 +53,8 @@ export function create(data = {}) {
     let cols = Math.round(width / cellW);
     cols = Math.max(1, Math.min(12, cols));
     gridEl.style.setProperty("--cols", cols);
+    const cell = width / cols;
+    gridEl.style.gridAutoRows = `${cell}px`;
     adjustHeight();
   }
 

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -53,6 +53,8 @@ export function create(data = {}) {
     let cols = Math.round(width / cellW);
     cols = Math.max(1, Math.min(12, cols));
     gridEl.style.setProperty("--cols", cols);
+    const cell = width / cols;
+    gridEl.style.gridAutoRows = `${cell}px`;
     adjustHeight();
   }
 


### PR DESCRIPTION
## Summary
- allow setting `gridAutoRows` when a container recalculates columns
- apply same fix to native containers
- define default `grid-auto-rows` in CSS so cards resize correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852f38400848328afbd7648d9ed404f