### PR TITLE
Fix card height in GridStack layout

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -29,6 +29,7 @@ body{margin:0;font-family:sans-serif}
   background:#fff;border:2px solid #00000020;border-radius:8px;
   display:flex;flex-direction:column;
   height:100%;
+  min-height:100%;
   padding:.5rem
 }
 .grid-stack>.grid-stack-item>.grid-stack-item-content{
@@ -115,7 +116,7 @@ body{margin:0;font-family:sans-serif}
 @media (prefers-color-scheme: dark){
   body{background:#121212;color:#fff}
   #fab{background:#0d6efd}
-  .grid-stack-item-content{background:#1e1e1e;border-color:#ffffff33}
+  .grid-stack-item-content{background:#1e1e1e;border-color:#ffffff33;height:100%}
   .grid-stack-item-content[data-locked="true"] textarea{background:#333}
 }
 


### PR DESCRIPTION
## Summary
- ensure `.grid-stack-item-content` always takes up the full grid item height
- keep same rule for dark theme

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68530984690c832895be5f88ce9ffd21