### PR TITLE
Fix container card resizing

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -172,6 +172,8 @@ grid.el.addEventListener("movein", (e) => {
   const gridEl = targetEl?.querySelector(".native-grid");
   if (!gridEl) return;
   grid.removeWidget(cardEl);
+  GridStack.Utils.removePositioningStyles(cardEl);
+  cardEl.classList.remove("grid-stack-item");
   gridEl.appendChild(cardEl);
   cardEl.dataset.parent = targetId;
   Store.setParent(cardEl.getAttribute("gs-id"), targetId);


### PR DESCRIPTION
## Summary
- remove GridStack positioning and classes when moving cards into a container

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68530f2869e08328a67366d712c14151