### PR TITLE
Implement container layout tweaks

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -32,6 +32,7 @@ body{margin:0;font-family:sans-serif}
   min-height:100%;
   padding:.5rem
 }
+.grid-stack-item-content.container{min-width:40%}
 .grid-stack>.grid-stack-item>.grid-stack-item-content{
   box-sizing:border-box;
 }
@@ -53,13 +54,14 @@ body{margin:0;font-family:sans-serif}
 }
 
 .container{transition:min-height .3s ease;}
-.container .collapse__header{display:flex;align-items:center;gap:.25rem}
+.container .collapse__header{display:flex;align-items:center;gap:.25rem;height:100%}
 .container .collapse__header h6{flex:1}
 .container .collapse__header button{background:none;border:none;cursor:pointer}
 .container .collapse__body{overflow-y:auto;overflow-x:hidden;padding:8px}
 .container .collapse__body::-webkit-scrollbar{width:8px}
 .container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
 .container .subgrid{min-height:100px}
+.container .card-wrapper{width:100%}
 .container .native-grid{
   display:grid;
   gap:16px;

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -2,6 +2,8 @@ import * as Store from "../store.js";
 import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
 
+const MAX_COLS = 3;
+
 export function create(data = {}) {
   const item = {
     type: "container-native",
@@ -25,7 +27,11 @@ export function create(data = {}) {
         <button class="add-card" aria-label="Add card">+</button>
         <button class="delete" aria-label="Delete">🗑️</button>
       </div>
-      <div class="collapse__body native-grid"></div>
+      <div class="collapse__body">
+        <div class="card-wrapper">
+          <div class="native-grid"></div>
+        </div>
+      </div>
     </div>`;
 
   const content = wrapper.firstElementChild;
@@ -34,6 +40,7 @@ export function create(data = {}) {
   const addBtn = content.querySelector("button.add-card");
   const delBtn = content.querySelector("button.delete");
   const bodyEl = content.querySelector(".collapse__body");
+  const wrapperEl = content.querySelector(".card-wrapper");
   const gridEl = content.querySelector(".native-grid");
 
   toggleBtn.setAttribute("aria-label", t("toggle"));
@@ -50,9 +57,10 @@ export function create(data = {}) {
     if (!parentGrid) return;
     if (bodyEl.style.display === "none") return;
     const cellW = parentGrid.cellWidth();
+    wrapperEl.style.maxWidth = `${cellW * MAX_COLS}px`;
     const width = gridEl.clientWidth;
     let cols = Math.round(width / cellW);
-    cols = Math.max(1, Math.min(12, cols));
+    cols = Math.max(1, Math.min(MAX_COLS, cols));
     gridEl.style.setProperty("--cols", cols);
     const cell = width / cols;
     gridEl.style.gridAutoRows = `${cell}px`;

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -2,6 +2,8 @@ import * as Store from "../store.js";
 import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
 
+const MAX_COLS = 3;
+
 export function create(data = {}) {
   const item = {
     type: "container",
@@ -24,7 +26,11 @@ export function create(data = {}) {
         <button class="add-card" aria-label="Add card">+</button>
         <button class="delete" aria-label="Delete">🗑️</button>
       </div>
-      <div class="collapse__body native-grid"></div>
+      <div class="collapse__body">
+        <div class="card-wrapper">
+          <div class="native-grid"></div>
+        </div>
+      </div>
     </div>`;
   const content = wrapper.firstElementChild;
   const titleEl = content.querySelector("h6");
@@ -32,6 +38,7 @@ export function create(data = {}) {
   const addBtn = content.querySelector("button.add-card");
   const delBtn = content.querySelector("button.delete");
   const bodyEl = content.querySelector(".collapse__body");
+  const wrapperEl = content.querySelector(".card-wrapper");
   const gridEl = content.querySelector(".native-grid");
   let dragEl = null;
 
@@ -49,9 +56,10 @@ export function create(data = {}) {
     if (!parentGrid) return;
     if (bodyEl.style.display === "none") return;
     const cellW = parentGrid.cellWidth();
+    wrapperEl.style.maxWidth = `${cellW * MAX_COLS}px`;
     const width = gridEl.clientWidth;
     let cols = Math.round(width / cellW);
-    cols = Math.max(1, Math.min(12, cols));
+    cols = Math.max(1, Math.min(MAX_COLS, cols));
     gridEl.style.setProperty("--cols", cols);
     const cell = width / cols;
     gridEl.style.gridAutoRows = `${cell}px`;


### PR DESCRIPTION
## Summary
- enforce a minimum width for container items
- keep collapse headers as tall as their parents
- wrap container card grid and limit columns

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853167b7b508328928018bc39b37bd9