### PR TITLE
Fix card height within containers

### DIFF
--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -63,6 +63,7 @@ export function create(data = {}) {
     gridEl.style.setProperty("--cols", cols);
     const cell = width / cols;
     gridEl.style.gridAutoRows = `${cell}px`;
+    Array.from(gridEl.children).forEach((c) => autoHeight(c));
     adjustHeight();
   }
 
@@ -80,6 +81,7 @@ export function create(data = {}) {
     const el = createCard({ parent: id });
     gridEl.appendChild(el);
     initCard(el);
+    autoHeight(el);
     saveChildren();
     adjustHeight();
   });
@@ -95,6 +97,7 @@ export function create(data = {}) {
     if (!gridEl.contains(el)) {
       gridEl.appendChild(el);
       initCard(el);
+      autoHeight(el);
       saveChildren();
       adjustHeight();
     }
@@ -139,6 +142,7 @@ export function create(data = {}) {
         const el = createCard(child);
         gridEl.appendChild(el);
         initCard(el, opts);
+        autoHeight(el);
       });
     }
   }

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -62,6 +62,7 @@ export function create(data = {}) {
     gridEl.style.setProperty("--cols", cols);
     const cell = width / cols;
     gridEl.style.gridAutoRows = `${cell}px`;
+    Array.from(gridEl.children).forEach((c) => autoHeight(c));
     adjustHeight();
   }
 
@@ -77,6 +78,7 @@ export function create(data = {}) {
     const el = createCard({ parent: id });
     gridEl.appendChild(el);
     initCard(el);
+    autoHeight(el);
     saveChildren();
     adjustHeight();
   });
@@ -92,6 +94,7 @@ export function create(data = {}) {
     if (!gridEl.contains(el)) {
       gridEl.appendChild(el);
       initCard(el);
+      autoHeight(el);
       saveChildren();
       adjustHeight();
     }
@@ -115,6 +118,7 @@ export function create(data = {}) {
         const el = createCard(child);
         gridEl.appendChild(el);
         initCard(el, opts);
+        autoHeight(el);
       });
     }
   }


### PR DESCRIPTION
## Summary
- recalc card autoHeight when container columns change
- adjust card height on add and restore

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68532b3b96288328a9679602b3a8443d