### PR TITLE
Fix container move-in filter

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -157,7 +157,7 @@ document.addEventListener("keydown", navigateCards);
 grid.el.addEventListener("movein", (e) => {
   const cardEl = e.target;
   const containers = Object.values(Store.data.items).filter(
-    (i) => i.type === "container",
+    (i) => i.type === "container" || i.type === "container-native",
   );
   if (!containers.length) return;
   let targetId = containers[0].id;


### PR DESCRIPTION
## Summary
- allow sending cards to native containers when using the `move in` feature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68542082c7c48328951100ba920659b1