### PR TITLE
Adjust container and card height limits

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -32,6 +32,9 @@ body{margin:0;font-family:sans-serif}
   min-height:100%;
   padding:.5rem
 }
+.grid-stack-item-content.container{
+  max-height:800px;
+}
 .grid-stack>.grid-stack-item>.grid-stack-item-content{
   box-sizing:border-box;
 }
@@ -63,17 +66,19 @@ body{margin:0;font-family:sans-serif}
 .container .card-wrapper{
   width:100%;
   height:100%;
+  max-height:800px;
 }
 .container .native-grid{
   display:grid;
   gap:16px;
   grid-template-columns:repeat(var(--cols,3),1fr);
   grid-auto-rows:100px;
-  min-height:100px
+  min-height:100px;
+  max-height:800px;
 }
 .container .native-grid>[gs-id]{
   min-width:0;
-  min-height:350px;
+  min-height:500px;
 }
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}


### PR DESCRIPTION
## Summary
- limit the height of container elements to 800px
- increase default card height in containers to 500px

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68555bea0b088328b83df82bfee6f4fe