### PR TITLE
Set max height for native grids

### DIFF
--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -31,7 +31,7 @@ export function create(data = {}) {
       </div>
       <div class="collapse__body">
         <div class="card-wrapper">
-          <div class="native-grid"></div>
+          <div class="native-grid" style="max-height: 800px"></div>
         </div>
       </div>
     </div>`;

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -30,7 +30,7 @@ export function create(data = {}) {
       </div>
       <div class="collapse__body">
         <div class="card-wrapper">
-          <div class="native-grid"></div>
+          <div class="native-grid" style="max-height: 800px"></div>
         </div>
       </div>
     </div>`;


### PR DESCRIPTION
## Summary
- add inline style with `max-height: 800px` to the `.native-grid` element in container components

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68555f205e2c832884506e14316cefaa