### PR TITLE
Remove redundant inline max-height

### DIFF
--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -31,7 +31,7 @@ export function create(data = {}) {
       </div>
       <div class="collapse__body">
         <div class="card-wrapper">
-          <div class="native-grid" style="max-height: 800px"></div>
+          <div class="native-grid"></div>
         </div>
       </div>
     </div>`;

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -30,7 +30,7 @@ export function create(data = {}) {
       </div>
       <div class="collapse__body">
         <div class="card-wrapper">
-          <div class="native-grid" style="max-height: 800px"></div>
+          <div class="native-grid"></div>
         </div>
       </div>
     </div>`;


### PR DESCRIPTION
## Summary
- drop inline `max-height` style in container templates

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855624681988328b56895ea264b6e84