### PR TITLE
Add max-height style to container elements

### DIFF
--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -22,7 +22,7 @@ export function create(data = {}) {
   wrapper.setAttribute("gs-id", id);
   wrapper.dataset.parent = item.parent;
   wrapper.innerHTML = `
-    <div class="grid-stack-item-content container">
+    <div class="grid-stack-item-content container" style="max-height:800px">
       <div class="collapse__header">
         <button class="toggle" aria-label="Toggle">▾</button>
         <h6 contenteditable="true"></h6>

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -21,7 +21,7 @@ export function create(data = {}) {
   wrapper.setAttribute("gs-id", id);
   wrapper.dataset.parent = item.parent;
   wrapper.innerHTML = `
-    <div class="grid-stack-item-content container">
+    <div class="grid-stack-item-content container" style="max-height:800px">
       <div class="collapse__header">
         <button class="toggle" aria-label="Toggle">▾</button>
         <h6 contenteditable="true"></h6>


### PR DESCRIPTION
## Summary
- enforce max-height of `grid-stack-item-content container` divs via inline style

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685563de7f088328bbc5e16d1a5c912c