### PR TITLE
Set default card height to 500px in containers

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -79,6 +79,7 @@ body{margin:0;font-family:sans-serif}
 .container .native-grid>[gs-id]{
   min-width:0;
   min-height:500px;
+  height:500px;
 }
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}


### PR DESCRIPTION
## Summary
- enforce 500px height for cards inside containers

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685564c1a7648328801e9e844f3691fe