### PR TITLE
Limit container height at runtime

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,6 +9,8 @@ import * as Auth from "./drive/auth.js";
 import * as Drive from "./drive/sync.js";
 import { t, getLanguage } from "./i18n.js";
 
+const MAX_CONTAINER_PX = 700;
+
 let dragItem = null;
 
 function attachGridEvents(g) {
@@ -25,6 +27,23 @@ function attachGridEvents(g) {
     Store.save();
     if (g === grid) saveLayout();
   });
+
+  g.on("resizestop", (_e, el) => {
+    enforceMaxHeight(g, el);
+    if (g === grid) saveLayout();
+  });
+}
+
+function enforceMaxHeight(g, el) {
+  if (!el || !el.querySelector(".container")) return;
+  const cellH = g.getCellHeight();
+  if (!cellH) return;
+  const node = el.gridstackNode;
+  if (!node) return;
+  const maxRows = Math.ceil(MAX_CONTAINER_PX / cellH);
+  if (node.h > maxRows) {
+    g.update(el, { h: maxRows });
+  }
 }
 
 const grid = GridStack.init(


### PR DESCRIPTION
## Summary
- enforce container height limit when grid items are resized
- add constant with max container height

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685569aba8248328a58e144813b345af