### PR TITLE
Set size limits for container cards

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -77,9 +77,10 @@ body{margin:0;font-family:sans-serif}
   max-height:700px;
 }
 .container .native-grid>[gs-id]{
-  min-width:0;
-  min-height:500px;
-  height:500px;
+  min-width:400px;
+  max-width:500px;
+  min-height:400px;
+  max-height:600px;
 }
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -6,6 +6,10 @@ import Sortable from "sortablejs";
 
 const MAX_COLS = 12;
 const MAX_HEIGHT_PX = 700;
+const MIN_CARD_WIDTH_PX = 400;
+const MAX_CARD_WIDTH_PX = 500;
+const MIN_CARD_HEIGHT_PX = 400;
+const MAX_CARD_HEIGHT_PX = 600;
 
 export function create(data = {}) {
   const item = {
@@ -152,6 +156,12 @@ export function create(data = {}) {
     interact(el)
       .resizable({
         edges: { bottom: true, right: true },
+        modifiers: [
+          interact.modifiers.restrictSize({
+            min: { width: MIN_CARD_WIDTH_PX, height: MIN_CARD_HEIGHT_PX },
+            max: { width: MAX_CARD_WIDTH_PX, height: MAX_CARD_HEIGHT_PX },
+          }),
+        ],
         listeners: {
           move(event) {
             const cols =

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -6,6 +6,10 @@ import Sortable from "sortablejs";
 
 const MAX_COLS = 12;
 const MAX_HEIGHT_PX = 700;
+const MIN_CARD_WIDTH_PX = 400;
+const MAX_CARD_WIDTH_PX = 500;
+const MIN_CARD_HEIGHT_PX = 400;
+const MAX_CARD_HEIGHT_PX = 600;
 
 export function create(data = {}) {
   const item = {
@@ -141,6 +145,12 @@ export function create(data = {}) {
     interact(el)
       .resizable({
         edges: { bottom: true, right: true },
+        modifiers: [
+          interact.modifiers.restrictSize({
+            min: { width: MIN_CARD_WIDTH_PX, height: MIN_CARD_HEIGHT_PX },
+            max: { width: MAX_CARD_WIDTH_PX, height: MAX_CARD_HEIGHT_PX },
+          }),
+        ],
         listeners: {
           move(event) {
             const cols =


### PR DESCRIPTION
## Summary
- limit card dimensions within containers to 400-500px width and 400-600px height
- enforce the same constraints during interactive resize

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855703afb388328bc1833eb9fe35756