### PR TITLE
Adjust card sizing and wrapping

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -67,12 +67,14 @@ body{margin:0;font-family:sans-serif}
   width:100%;
   height:100%;
   max-height:700px;
+  display:flex;
+  flex-wrap:wrap;
 }
 .container .native-grid{
   display:grid;
   gap:16px;
-  grid-template-columns:repeat(var(--cols,3),1fr);
-  grid-auto-rows:100px;
+  grid-template-columns:repeat(auto-fit,minmax(400px,1fr));
+  grid-auto-rows:400px;
   min-height:100px;
   max-height:700px;
 }
@@ -80,7 +82,7 @@ body{margin:0;font-family:sans-serif}
   min-width:400px;
   max-width:500px;
   min-height:400px;
-  max-height:600px;
+  max-height:400px;
 }
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -9,7 +9,7 @@ const MAX_HEIGHT_PX = 700;
 const MIN_CARD_WIDTH_PX = 400;
 const MAX_CARD_WIDTH_PX = 500;
 const MIN_CARD_HEIGHT_PX = 400;
-const MAX_CARD_HEIGHT_PX = 600;
+const MAX_CARD_HEIGHT_PX = 400;
 
 export function create(data = {}) {
   const item = {
@@ -77,9 +77,7 @@ export function create(data = {}) {
     let cols = Math.round(width / cellW);
     cols = Math.max(1, Math.min(MAX_COLS, cols));
     gridEl.style.setProperty("--cols", cols);
-    const cell = width / cols;
-    if (!cell) return;
-    gridEl.style.gridAutoRows = `${cell}px`;
+    gridEl.style.gridAutoRows = `${MIN_CARD_HEIGHT_PX}px`;
     Array.from(gridEl.children).forEach((c) => autoHeight(c));
     adjustHeight();
   }
@@ -164,11 +162,7 @@ export function create(data = {}) {
         ],
         listeners: {
           move(event) {
-            const cols =
-              parseInt(getComputedStyle(gridEl).getPropertyValue("--cols")) ||
-              1;
-            const cell = gridEl.clientWidth / cols;
-            if (!cell) return;
+            const cell = MIN_CARD_HEIGHT_PX;
             const w = Math.max(1, Math.round(event.rect.width / cell));
             const h = Math.max(1, Math.round(event.rect.height / cell));
             el.dataset.w = w;
@@ -192,12 +186,8 @@ export function create(data = {}) {
   }
 
   function autoHeight(el) {
-    const cols =
-      parseInt(getComputedStyle(gridEl).getPropertyValue("--cols")) || 1;
-    const cell = gridEl.clientWidth / cols;
-    if (!cell) return;
     const content = el.firstElementChild;
-    const newH = Math.max(1, Math.ceil(content.offsetHeight / cell));
+    const newH = Math.max(1, Math.ceil(content.offsetHeight / MIN_CARD_HEIGHT_PX));
     if (newH !== parseInt(el.dataset.h)) {
       el.dataset.h = newH;
       applySize(el);

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -9,7 +9,7 @@ const MAX_HEIGHT_PX = 700;
 const MIN_CARD_WIDTH_PX = 400;
 const MAX_CARD_WIDTH_PX = 500;
 const MIN_CARD_HEIGHT_PX = 400;
-const MAX_CARD_HEIGHT_PX = 600;
+const MAX_CARD_HEIGHT_PX = 400;
 
 export function create(data = {}) {
   const item = {
@@ -74,9 +74,7 @@ export function create(data = {}) {
     let cols = Math.round(width / cellW);
     cols = Math.max(1, Math.min(MAX_COLS, cols));
     gridEl.style.setProperty("--cols", cols);
-    const cell = width / cols;
-    if (!cell) return;
-    gridEl.style.gridAutoRows = `${cell}px`;
+    gridEl.style.gridAutoRows = `${MIN_CARD_HEIGHT_PX}px`;
     Array.from(gridEl.children).forEach((c) => autoHeight(c));
     adjustHeight();
   }
@@ -153,11 +151,7 @@ export function create(data = {}) {
         ],
         listeners: {
           move(event) {
-            const cols =
-              parseInt(getComputedStyle(gridEl).getPropertyValue("--cols")) ||
-              1;
-            const cell = gridEl.clientWidth / cols;
-            if (!cell) return;
+            const cell = MIN_CARD_HEIGHT_PX;
             const w = Math.max(1, Math.round(event.rect.width / cell));
             const h = Math.max(1, Math.round(event.rect.height / cell));
             el.dataset.w = w;
@@ -188,12 +182,8 @@ export function create(data = {}) {
   });
 
   function autoHeight(el) {
-    const cols =
-      parseInt(getComputedStyle(gridEl).getPropertyValue("--cols")) || 1;
-    const cell = gridEl.clientWidth / cols;
-    if (!cell) return;
     const content = el.firstElementChild;
-    const newH = Math.max(1, Math.ceil(content.offsetHeight / cell));
+    const newH = Math.max(1, Math.ceil(content.offsetHeight / MIN_CARD_HEIGHT_PX));
     if (newH !== parseInt(el.dataset.h)) {
       el.dataset.h = newH;
       applySize(el);


### PR DESCRIPTION
## Summary
- keep container cards fixed at 400px tall
- allow cards to wrap within containers

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68557361c7cc8328aa222e257ae136aa