### PR TITLE
Adjust note grid spacing

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -74,15 +74,15 @@ body{margin:0;font-family:sans-serif}
   display:grid;
   gap:16px;
   grid-template-columns:repeat(auto-fit,minmax(400px,1fr));
-  grid-auto-rows:400px;
+  grid-auto-rows:200px;
   min-height:100px;
   max-height:700px;
 }
 .container .native-grid>[gs-id]{
   min-width:400px;
   max-width:500px;
-  min-height:400px;
-  max-height:400px;
+  min-height:200px;
+  max-height:200px;
 }
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -8,8 +8,8 @@ const MAX_COLS = 12;
 const MAX_HEIGHT_PX = 700;
 const MIN_CARD_WIDTH_PX = 400;
 const MAX_CARD_WIDTH_PX = 500;
-const MIN_CARD_HEIGHT_PX = 400;
-const MAX_CARD_HEIGHT_PX = 400;
+const MIN_CARD_HEIGHT_PX = 200;
+const MAX_CARD_HEIGHT_PX = 200;
 
 export function create(data = {}) {
   const item = {

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -8,8 +8,8 @@ const MAX_COLS = 12;
 const MAX_HEIGHT_PX = 700;
 const MIN_CARD_WIDTH_PX = 400;
 const MAX_CARD_WIDTH_PX = 500;
-const MIN_CARD_HEIGHT_PX = 400;
-const MAX_CARD_HEIGHT_PX = 400;
+const MIN_CARD_HEIGHT_PX = 200;
+const MAX_CARD_HEIGHT_PX = 200;
 
 export function create(data = {}) {
   const item = {


### PR DESCRIPTION
## Summary
- use smaller row height for note grids
- update card size constants accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68558ec1bf588328aad3bf9941b653d8