### PR TITLE
Reduce card spacing

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -72,7 +72,7 @@ body{margin:0;font-family:sans-serif}
 }
 .container .native-grid{
   display:grid;
-  gap:16px;
+  gap:8px;
   grid-template-columns:repeat(auto-fit,minmax(400px,1fr));
   grid-auto-rows:200px;
   min-height:100px;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -48,7 +48,7 @@ function enforceMaxHeight(g, el) {
 
 const grid = GridStack.init(
   {
-    margin: 8,
+    margin: 4,
     column: 12,
     float: false,
     resizable: { handles: "e, se, s, w" },


### PR DESCRIPTION
## Summary
- reduce gap between cards in containers
- reduce grid stack margin so cards are closer

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68559302b2748328a841d0e546ba6a7b