### PR TITLE
Switch containers back to GridStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Offline support is enabled by default and registered from `app.js`.
 ## Loading GridStack
 
 GridStack is installed via npm and imported as an ES module from `app.js`.
-Containers no longer use a nested GridStack instance. Instead, their internal
-layout relies on a native CSS Grid controlled with JavaScript.
+Containers use a nested GridStack instance to manage their internal layout.
 
 ### Passo de teste 4.2
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
     <button id="fab-main" aria-label="Adicionar" class="fab-main">+</button>
     <button id="fab-card" class="fab-option" aria-label="Novo card">📄</button>
     <button id="fab-container" class="fab-option" aria-label="Novo container">📦</button>
-    <button id="fab-container-native" class="fab-option" aria-label="Novo container nativo">🧩</button>
     <button id="fab-folder" class="fab-option" aria-label="Nova pasta">📁</button>
   </div>
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -63,27 +63,6 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__body::-webkit-scrollbar{width:8px}
 .container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
 .container .subgrid{min-height:100px}
-.container .card-wrapper{
-  width:100%;
-  height:100%;
-  max-height:700px;
-  display:flex;
-  flex-wrap:wrap;
-}
-.container .native-grid{
-  display:grid;
-  gap:8px;
-  grid-template-columns:repeat(auto-fit,minmax(400px,1fr));
-  grid-auto-rows:200px;
-  min-height:100px;
-  max-height:700px;
-}
-.container .native-grid>[gs-id]{
-  min-width:400px;
-  max-width:500px;
-  min-height:200px;
-  max-height:200px;
-}
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}
 .container.collapsed::after{

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -1,15 +1,9 @@
+import { GridStack } from "gridstack";
 import * as Store from "../store.js";
 import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
-import interact from "interactjs";
-import Sortable from "sortablejs";
 
-const MAX_COLS = 12;
 const MAX_HEIGHT_PX = 700;
-const MIN_CARD_WIDTH_PX = 400;
-const MAX_CARD_WIDTH_PX = 500;
-const MIN_CARD_HEIGHT_PX = 200;
-const MAX_CARD_HEIGHT_PX = 200;
 
 export function create(data = {}) {
   const item = {
@@ -34,9 +28,7 @@ export function create(data = {}) {
         <button class="delete" aria-label="Delete">🗑️</button>
       </div>
       <div class="collapse__body">
-        <div class="card-wrapper">
-          <div class="native-grid"></div>
-        </div>
+        <div class="grid-stack subgrid" id="sub-${id}"></div>
       </div>
     </div>`;
   const content = wrapper.firstElementChild;
@@ -45,15 +37,7 @@ export function create(data = {}) {
   const addBtn = content.querySelector("button.add-card");
   const delBtn = content.querySelector("button.delete");
   const bodyEl = content.querySelector(".collapse__body");
-  const wrapperEl = content.querySelector(".card-wrapper");
-  const gridEl = content.querySelector(".native-grid");
-  const sortable = new Sortable(gridEl, {
-    animation: 150,
-    onEnd() {
-      saveChildren();
-      adjustHeight();
-    },
-  });
+  const subEl = content.querySelector(".subgrid");
 
   toggleBtn.setAttribute("aria-label", t("toggle"));
   addBtn.setAttribute("aria-label", t("addCard"));
@@ -64,36 +48,46 @@ export function create(data = {}) {
     Store.patch(id, { title: titleEl.textContent });
   });
 
+  const subgrid = GridStack.init(
+    {
+      margin: 8,
+      column: 12,
+      float: false,
+      acceptWidgets: true,
+      dragOut: true,
+      subGrid: true,
+    },
+    subEl,
+  );
   function updateColumns() {
     const parentGrid = wrapper.closest(".grid-stack")?.gridstack;
     if (!parentGrid) return;
     if (bodyEl.style.display === "none") return;
     const cellW = parentGrid.cellWidth();
-    const width = gridEl.clientWidth;
-    if (!width) return;
+    const width = subEl.clientWidth;
     let cols = Math.round(width / cellW);
-    cols = Math.max(1, Math.min(MAX_COLS, cols));
-    gridEl.style.setProperty("--cols", cols);
-    gridEl.style.gridAutoRows = `${MIN_CARD_HEIGHT_PX}px`;
-    Array.from(gridEl.children).forEach((c) => autoHeight(c));
+    cols = Math.max(1, Math.min(12, cols));
+    if (subgrid.opts.column !== cols) subgrid.column(cols);
+    const cellH = parentGrid.getCellHeight();
+    if (subgrid.opts.cellHeight !== cellH) subgrid.cellHeight(cellH);
     adjustHeight();
   }
-
   const ro = new ResizeObserver(updateColumns);
-  ro.observe(gridEl);
+  ro.observe(subEl);
   setTimeout(() => {
     updateColumns();
     restoreChildren();
     adjustHeight();
   });
+  subgrid.on("change", () => {
+    item.layout = subgrid.save();
+    Store.patch(id, { layout: item.layout });
+    adjustHeight();
+  });
 
   addBtn.addEventListener("click", () => {
     const el = createCard({ parent: id });
-    gridEl.appendChild(el);
-    initCard(el);
-    autoHeight(el);
-    saveChildren();
-    adjustHeight();
+    subgrid.addWidget(el, { x: 0, y: 0, w: 3, h: 2 });
   });
 
   delBtn.addEventListener("click", () => {
@@ -102,125 +96,23 @@ export function create(data = {}) {
     Store.remove(id);
   });
 
-  wrapper.addEventListener("childadded", (e) => {
-    const el = e.detail.el;
-    if (!gridEl.contains(el)) {
-      gridEl.appendChild(el);
-      initCard(el);
-      autoHeight(el);
-      saveChildren();
-      adjustHeight();
-    }
-  });
-
   function restoreChildren() {
-    if (item.layout.length && !item.children.length) {
+    if (item.layout.length) {
+      subgrid.removeAll();
       item.layout.forEach((opts) => {
         const child = Store.data.items[opts.id];
         if (!child) return;
-        item.children.push(opts.id);
+        let el;
+        if (child.type === "card") el = createCard(child);
+        if (el) subgrid.addWidget(el, opts);
       });
-      Store.patch(id, { children: item.children });
-    }
-    if (item.children.length) {
-      gridEl.innerHTML = "";
+    } else if (item.children.length) {
       item.children.forEach((cid) => {
         const child = Store.data.items[cid];
         if (!child) return;
-        const opts = item.layout.find((o) => o.id === cid) || { w: 1, h: 1 };
         const el = createCard(child);
-        gridEl.appendChild(el);
-        initCard(el, opts);
-        autoHeight(el);
+        subgrid.addWidget(el, { x: 0, y: 0, w: 3, h: 2 });
       });
-    }
-  }
-
-  function initCard(el, opts = {}) {
-    el.dataset.w = opts.w || 1;
-    el.dataset.h = opts.h || 1;
-    applySize(el);
-    interact(el)
-      .resizable({
-        edges: { bottom: true, right: true },
-        modifiers: [
-          interact.modifiers.restrictSize({
-            min: { width: MIN_CARD_WIDTH_PX, height: MIN_CARD_HEIGHT_PX },
-            max: { width: MAX_CARD_WIDTH_PX, height: MAX_CARD_HEIGHT_PX },
-          }),
-        ],
-        listeners: {
-          move(event) {
-            const cell = MIN_CARD_HEIGHT_PX;
-            const w = Math.max(1, Math.round(event.rect.width / cell));
-            const h = Math.max(1, Math.round(event.rect.height / cell));
-            el.dataset.w = w;
-            el.dataset.h = h;
-            applySize(el);
-            adjustHeight();
-          },
-          end() {
-            saveChildren();
-          },
-        },
-      });
-    el.addEventListener("moveout", onMoveOut);
-    const textarea = el.querySelector("textarea");
-    if (textarea) textarea.addEventListener("input", () => autoHeight(el));
-  }
-
-  function applySize(el) {
-    el.style.gridColumnEnd = `span ${el.dataset.w}`;
-    el.style.gridRowEnd = `span ${el.dataset.h}`;
-  }
-
-  // dragover/drop handled by interact.js
-
-  gridEl.addEventListener("removed", () => {
-    saveChildren();
-    adjustHeight();
-  });
-
-  function autoHeight(el) {
-    const content = el.firstElementChild;
-    const newH = Math.max(1, Math.ceil(content.offsetHeight / MIN_CARD_HEIGHT_PX));
-    if (newH !== parseInt(el.dataset.h)) {
-      el.dataset.h = newH;
-      applySize(el);
-      saveChildren();
-      adjustHeight();
-    }
-  }
-
-  // resizing handled by interact.js
-
-  function onMoveOut(e) {
-    const el = e.currentTarget;
-    const rootGrid = document.getElementById("grid")?.gridstack;
-    if (!rootGrid) return;
-    gridEl.removeChild(el);
-    rootGrid.addWidget(el, { x: 0, y: 0, w: 3, h: 2 });
-    Store.setParent(el.getAttribute("gs-id"), "root");
-    saveChildren();
-    saveRootLayout();
-  }
-
-  function saveChildren() {
-    const arr = Array.from(gridEl.children).map((c) => ({
-      id: c.getAttribute("gs-id"),
-      w: parseInt(c.dataset.w || 1),
-      h: parseInt(c.dataset.h || 1),
-    }));
-    item.layout = arr;
-    item.children = arr.map((o) => o.id);
-    Store.patch(id, { children: item.children, layout: item.layout });
-  }
-
-  function saveRootLayout() {
-    const rootGrid = document.getElementById("grid")?.gridstack;
-    if (rootGrid) {
-      Store.data.layout = rootGrid.save();
-      Store.save();
     }
   }
 
@@ -253,8 +145,7 @@ export function create(data = {}) {
     parentGrid.save();
   }
 
-  // initialize state after caller inserts element into the grid
   setCollapsed(item.collapsed);
 
-  return { el: wrapper, adjust: adjustHeight, setCollapsed };
+  return { el: wrapper, grid: subgrid, adjust: adjustHeight, setCollapsed };
 }


### PR DESCRIPTION
## Summary
- restore GridStack usage inside containers
- drop native grid container option and button
- update docs and styles

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855959c46108328b4bc36dea7cc2f5c