### PR TITLE
Fix container card width

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -64,6 +64,7 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__body::-webkit-scrollbar{width:8px}
 .container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
 .container .subgrid{min-height:100px}
+.container .subgrid>.grid-stack-item{min-width:400px;max-width:500px}
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}
 .container.collapsed::after{

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -71,10 +71,9 @@ export function create(data = {}) {
     const parentGrid = wrapper.closest(".grid-stack")?.gridstack;
     if (!parentGrid) return;
     if (bodyEl.style.display === "none") return;
-    const cellW = parentGrid.cellWidth();
     const width = gridEl.clientWidth;
     if (!width) return;
-    let cols = Math.round(width / cellW);
+    let cols = Math.floor(width / MIN_CARD_WIDTH_PX);
     cols = Math.max(1, Math.min(MAX_COLS, cols));
     gridEl.style.setProperty("--cols", cols);
     gridEl.style.gridAutoRows = `${MIN_CARD_HEIGHT_PX}px`;

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -65,7 +65,7 @@ export function create(data = {}) {
   function updateColumns() {
     if (bodyEl.style.display === "none") return;
     const width = subEl.clientWidth;
-    let cols = Math.round(width / CARD_SIZE);
+    let cols = Math.floor(width / CARD_SIZE);
     cols = Math.max(1, cols);
     if (subgrid.opts.column !== cols) subgrid.column(cols);
     if (subgrid.opts.cellHeight !== CARD_SIZE) subgrid.cellHeight(CARD_SIZE);


### PR DESCRIPTION
## Summary
- ensure subgrid columns are calculated using `Math.floor` so cards keep width
- add width limits to items inside container grids

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68559cb219048328bc9fb74d28b02c3b