### PR TITLE
Enable multi-column containers

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -64,7 +64,7 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__body::-webkit-scrollbar{width:8px}
 .container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
 .container .subgrid{min-height:100px}
-.container .subgrid>.grid-stack-item{min-width:400px;max-width:500px}
+.container .subgrid>.grid-stack-item{min-width:300px;max-width:400px}
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}
 .container.collapsed::after{

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -6,8 +6,8 @@ import Sortable from "sortablejs";
 
 const MAX_COLS = 12;
 const MAX_HEIGHT_PX = 700;
-const MIN_CARD_WIDTH_PX = 400;
-const MAX_CARD_WIDTH_PX = 500;
+const MIN_CARD_WIDTH_PX = 300;
+const MAX_CARD_WIDTH_PX = 400;
 const MIN_CARD_HEIGHT_PX = 200;
 const MAX_CARD_HEIGHT_PX = 200;
 

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -4,7 +4,8 @@ import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
 
 const MAX_HEIGHT_PX = 700;
-const CARD_SIZE = 400;
+// Base width/height for cards within a container
+const CARD_SIZE = 300;
 
 export function create(data = {}) {
   const item = {


### PR DESCRIPTION
## Summary
- allow cards in containers to flow into multiple columns
- update JS constants so containers calculate columns from 300px cards

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68559fd91774832880d86c28324a5abf