### PR TITLE
Remove container height limit

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -32,9 +32,6 @@ body{margin:0;font-family:sans-serif}
   min-height:100%;
   padding:.5rem
 }
-.grid-stack-item-content.container{
-  max-height:700px;
-}
 .grid-stack>.grid-stack-item>.grid-stack-item-content{
   box-sizing:border-box;
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8,8 +8,6 @@ import * as Auth from "./drive/auth.js";
 import * as Drive from "./drive/sync.js";
 import { t, getLanguage } from "./i18n.js";
 
-const MAX_CONTAINER_PX = 700;
-
 let dragItem = null;
 
 function attachGridEvents(g) {
@@ -28,21 +26,8 @@ function attachGridEvents(g) {
   });
 
   g.on("resizestop", (_e, el) => {
-    enforceMaxHeight(g, el);
     if (g === grid) saveLayout();
   });
-}
-
-function enforceMaxHeight(g, el) {
-  if (!el || !el.querySelector(".container")) return;
-  const cellH = g.getCellHeight();
-  if (!cellH) return;
-  const node = el.gridstackNode;
-  if (!node) return;
-  const maxRows = Math.ceil(MAX_CONTAINER_PX / cellH);
-  if (node.h > maxRows) {
-    g.update(el, { h: maxRows });
-  }
 }
 
 const grid = GridStack.init(

--- a/src/js/ui/container-native.js
+++ b/src/js/ui/container-native.js
@@ -5,7 +5,6 @@ import interact from "interactjs";
 import Sortable from "sortablejs";
 
 const MAX_COLS = 12;
-const MAX_HEIGHT_PX = 700;
 const MIN_CARD_WIDTH_PX = 300;
 const MAX_CARD_WIDTH_PX = 400;
 const MIN_CARD_HEIGHT_PX = 200;
@@ -27,7 +26,7 @@ export function create(data = {}) {
   wrapper.setAttribute("gs-id", id);
   wrapper.dataset.parent = item.parent;
   wrapper.innerHTML = `
-    <div class="grid-stack-item-content container" style="max-height:${MAX_HEIGHT_PX}px">
+    <div class="grid-stack-item-content container">
       <div class="collapse__header">
         <button class="toggle" aria-label="Toggle">▾</button>
         <h6 contenteditable="true"></h6>
@@ -247,11 +246,7 @@ export function create(data = {}) {
     if (!parentGrid) return;
     const cellH = parentGrid.getCellHeight();
     if (!cellH) return;
-    const maxRows = Math.ceil(MAX_HEIGHT_PX / cellH);
-    const newH = Math.min(
-      maxRows,
-      Math.max(1, Math.ceil(content.offsetHeight / cellH)),
-    );
+    const newH = Math.max(1, Math.ceil(content.offsetHeight / cellH));
     parentGrid.update(wrapper, { h: newH });
     parentGrid.save();
   }

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -3,7 +3,6 @@ import * as Store from "../store.js";
 import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
 
-const MAX_HEIGHT_PX = 700;
 // Base width/height for cards within a container
 const CARD_SIZE = 300;
 
@@ -22,7 +21,7 @@ export function create(data = {}) {
   wrapper.setAttribute("gs-id", id);
   wrapper.dataset.parent = item.parent;
   wrapper.innerHTML = `
-    <div class="grid-stack-item-content container" style="max-height:${MAX_HEIGHT_PX}px">
+    <div class="grid-stack-item-content container">
       <div class="collapse__header">
         <button class="toggle" aria-label="Toggle">▾</button>
         <h6 contenteditable="true"></h6>
@@ -137,11 +136,7 @@ export function create(data = {}) {
     if (!parentGrid) return;
     const cellH = parentGrid.getCellHeight();
     if (!cellH) return;
-    const maxRows = Math.ceil(MAX_HEIGHT_PX / cellH);
-    const newH = Math.min(
-      maxRows,
-      Math.max(1, Math.ceil(content.offsetHeight / cellH)),
-    );
+    const newH = Math.max(1, Math.ceil(content.offsetHeight / cellH));
     parentGrid.update(wrapper, { h: newH });
     parentGrid.save();
   }


### PR DESCRIPTION
## Summary
- allow cards to stack without height restriction by removing max-height
- drop container height enforcement in JS
- keep build passing after install

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855a2bc00448328b8d57170b53eff02