### PR TITLE
Enable multiple cards per column in container

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -61,7 +61,7 @@ body{margin:0;font-family:sans-serif}
 .container .collapse__body::-webkit-scrollbar{width:8px}
 .container .collapse__body::-webkit-scrollbar-thumb{background:#007bff;border-radius:4px}
 .container .subgrid{min-height:100px}
-.container .subgrid>.grid-stack-item{min-width:300px;max-width:400px}
+.container .subgrid>.grid-stack-item{min-width:200px;max-width:400px}
 .container.collapsed{min-height:100px;height:100px;overflow:hidden;position:relative}
 .container.collapsed .collapse__body{display:none}
 .container.collapsed::after{

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -3,8 +3,9 @@ import * as Store from "../store.js";
 import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
 
-// Base width/height for cards within a container
-const CARD_SIZE = 300;
+// Base dimensions for cards within a container
+const CARD_MIN_WIDTH = 200;
+const CARD_HEIGHT = 300;
 
 export function create(data = {}) {
   const item = {
@@ -58,17 +59,17 @@ export function create(data = {}) {
       dragOut: true,
       subGrid: true,
       disableResize: true,
-      cellHeight: CARD_SIZE,
+      cellHeight: CARD_HEIGHT,
     },
     subEl,
   );
   function updateColumns() {
     if (bodyEl.style.display === "none") return;
     const width = subEl.clientWidth;
-    let cols = Math.floor(width / CARD_SIZE);
+    let cols = Math.floor(width / CARD_MIN_WIDTH);
     cols = Math.max(1, cols);
     if (subgrid.opts.column !== cols) subgrid.column(cols);
-    if (subgrid.opts.cellHeight !== CARD_SIZE) subgrid.cellHeight(CARD_SIZE);
+    if (subgrid.opts.cellHeight !== CARD_HEIGHT) subgrid.cellHeight(CARD_HEIGHT);
     adjustHeight();
   }
   const ro = new ResizeObserver(updateColumns);


### PR DESCRIPTION
## Summary
- tune container grid layout
- adjust container card min width

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855a4d783b8832890268a7140f23b00