### PR TITLE
Allow side-by-side cards in containers

### DIFF
--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -87,7 +87,7 @@ export function create(data = {}) {
 
   addBtn.addEventListener("click", () => {
     const el = createCard({ parent: id });
-    subgrid.addWidget(el, { x: 0, y: 0, w: 1, h: 1 });
+    subgrid.addWidget(el, { w: 1, h: 1, autoPosition: true });
   });
 
   delBtn.addEventListener("click", () => {
@@ -112,7 +112,7 @@ export function create(data = {}) {
         const child = Store.data.items[cid];
         if (!child) return;
         const el = createCard(child);
-        subgrid.addWidget(el, { x: 0, y: 0, w: 1, h: 1 });
+        subgrid.addWidget(el, { w: 1, h: 1, autoPosition: true });
       });
     }
   }


### PR DESCRIPTION
## Summary
- fix new container cards to autolayout horizontally

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855ae8b94848328864931a18e145af5