### PR TITLE
Fix container column calculation

### DIFF
--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -112,7 +112,7 @@ class Container {
 
   updateColumns() {
     if (this.bodyEl.style.display === "none") return;
-    const width = this.subEl.clientWidth;
+    const width = this.wrapper.offsetWidth;
     let cols = Math.max(1, Math.floor(width / MIN_WIDTH));
     if (this.subgrid.opts.column !== cols) this.subgrid.column(cols);
     const parentGrid = this.wrapper.closest(".grid-stack")?.gridstack;


### PR DESCRIPTION
## Summary
- adjust column calculation for nested grid using container width

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685696dea4f8832883c22cae30f5e29e