### PR TITLE
Enable multi-column containers

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -126,6 +126,8 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 95%;
+  margin: 0 auto;
 }
 .container-header {
   display: flex;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -119,9 +119,16 @@ function addCard(data = { x: 0, y: 0, w: 3, h: 2 }, g = grid, parent = "root") {
   if (g === grid) saveLayout();
 }
 
-function addContainer(data = { x: 0, y: 0, w: 6, h: 4 }) {
+function addContainer(data = { x: 0, y: 0, h: 4 }) {
+  const cols = grid.opts.column;
   const added = createContainer({});
-  grid.addWidget(added.el, data);
+  grid.addWidget(added.el, {
+    x: data.x ?? 0,
+    y: data.y ?? 0,
+    w: cols,
+    h: data.h ?? 4,
+    resizable: { handles: "s" },
+  });
   saveLayout();
 }
 

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -18,6 +18,7 @@ export function create(data = {}) {
   const wrapper = document.createElement("div");
   wrapper.setAttribute("gs-id", id);
   wrapper.dataset.parent = item.parent;
+  wrapper.dataset.type = "container";
   wrapper.innerHTML = `
     <div class="grid-stack-item-content container">
       <div class="container-header">
@@ -49,7 +50,7 @@ export function create(data = {}) {
   const subgrid = GridStack.init(
     {
       margin: 4,
-      column: 1,
+      column: 3,
       float: false,
       resizable: { handles: "e, se, s, w" },
       acceptWidgets: true,


### PR DESCRIPTION
## Summary
- support multiple columns inside containers
- keep containers full-width and disable width resizing
- center container layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856a0ae0b448328ba4ce3b13599d8e4