### PR TITLE
Fix container grid width issue

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -126,7 +126,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: 95%;
+  width: 90%;
   margin: 0 auto;
 }
 .container-header {

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -50,7 +50,7 @@ export function create(data = {}) {
   const subgrid = GridStack.init(
     {
       margin: 4,
-      column: 3,
+      column: "auto",
       float: false,
       resizable: { handles: "e, se, s, w" },
       acceptWidgets: true,


### PR DESCRIPTION
## Summary
- narrow container width to 90%
- let nested grid auto adjust columns

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856a69afb0c83288b053cfc1cef6398