### PR TITLE
Fix container width and keep width static

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -126,7 +126,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: 90%;
+  width: 95%;
   margin: 0 auto;
 }
 .container-header {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -220,7 +220,7 @@ async function restore() {
       let added;
       if (data.type === "container") {
         added = createContainer(data);
-        grid.addWidget(added.el, opts);
+        grid.addWidget(added.el, { ...opts, resizable: { handles: "s" } });
       } else if (data.type === "folder") {
         const el = createFolder(data);
         grid.addWidget(el, opts);


### PR DESCRIPTION
## Summary
- widen containers to 95%
- ensure restored containers only resize vertically so width stays fixed

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856a93ac6a08328af629e213a6f21c5