### PR TITLE
Fix container width resize

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -127,6 +127,8 @@ function addContainer(data = { x: 0, y: 0, h: 4 }) {
     y: data.y ?? 0,
     w: cols,
     h: data.h ?? 4,
+    minW: cols,
+    maxW: cols,
     resizable: { handles: "s" },
   });
   saveLayout();
@@ -143,7 +145,14 @@ function updateColumns() {
   let cols = 12;
   if (width < 600) cols = 3;
   else if (width < 1024) cols = 6;
-  if (grid.opts.column !== cols) grid.column(cols);
+  if (grid.opts.column !== cols) {
+    grid.column(cols);
+    document
+      .querySelectorAll('[data-type="container"]')
+      .forEach((el) => {
+        grid.update(el, { w: cols, minW: cols, maxW: cols });
+      });
+  }
 }
 window.addEventListener("resize", updateColumns);
 updateColumns();
@@ -220,7 +229,12 @@ async function restore() {
       let added;
       if (data.type === "container") {
         added = createContainer(data);
-        grid.addWidget(added.el, { ...opts, resizable: { handles: "s" } });
+        grid.addWidget(added.el, {
+          ...opts,
+          minW: opts.w,
+          maxW: opts.w,
+          resizable: { handles: "s" },
+        });
       } else if (data.type === "folder") {
         const el = createFolder(data);
         grid.addWidget(el, opts);


### PR DESCRIPTION
## Summary
- fix container width by locking min/max width when adding
- keep width locked on restore
- adapt containers when column count changes

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856abfca3a48328b5e4660896184cb0