### PR TITLE
Fix container width persistence

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -126,8 +126,8 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: 95%;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
 }
 .container-header {
   display: flex;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -268,6 +268,8 @@ async function start() {
     }
   }
   await restore();
+  // ensure containers span the full grid width after restoring layout
+  updateColumns();
 }
 
 start();


### PR DESCRIPTION
## Summary
- ensure containers take full grid width after restoring layout
- remove leftover container margin and width limit

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856b75ac2508328981db78a0df01c05