### PR TITLE
Set uniform grid spacing

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -32,8 +32,8 @@ function attachGridEvents(g) {
 
 const grid = GridStack.init(
   {
-    // add extra vertical spacing between grid items
-    margin: "16px 8px",
+    // standard gap between widgets as in the GridStack demo
+    margin: 10,
     column: 12,
     float: false,
     resizable: { handles: "e, se, s, w" },

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -54,8 +54,8 @@ export function create(data = {}) {
 
   const subgrid = GridStack.init(
     {
-      // match root grid spacing for consistency
-      margin: 8,
+      // use the same 10px gap as the main grid
+      margin: 10,
       column: "auto",
       float: false,
       resizable: { handles: "e, se, s, w" },

--- a/src/js/ui/folder.js
+++ b/src/js/ui/folder.js
@@ -45,7 +45,7 @@ export function create(data = {}) {
       item.desc = descEl.value;
       Store.patch(id, { desc: item.desc });
     });
-    const childGrid = GridStack.init({ column: 12, float: false, resizable:{ handles:'e, se, s, w' }, acceptWidgets: true, dragOut: true }, gridEl);
+    const childGrid = GridStack.init({ margin: 10, column: 12, float: false, resizable:{ handles:'e, se, s, w' }, acceptWidgets: true, dragOut: true }, gridEl);
     if (!childGrid) return;
 
     if (item.layout && item.layout.length) {


### PR DESCRIPTION
## Summary
- use default 10px margin for main grid
- match container subgrid to the same gap
- apply explicit margin to folder grids

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856f06aadb88328bf6ef27528ea6755