### PR TITLE
Load gridstack-extra CSS for better spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>FastNotes</title>
 
   <link href="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack.min.css" rel="stylesheet" />
+  <!-- required for custom column layouts (below 12 columns) -->
+  <link href="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-extra.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="/src/css/main.css" />
   <link rel="manifest" href="/manifest.json" />
   <script type="module" src="/src/js/app.js"></script>


### PR DESCRIPTION
## Summary
- load `gridstack-extra.min.css` so custom column layouts have proper spacing between elements

## Testing
- `npm install`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6856f554ab4883289e6c8f1e25768be7