### PR TITLE
Set vertical grid spacing

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -33,6 +33,10 @@ body {
   /* add spacing so items aren't flush against the viewport */
   padding-top: 1.5rem;
   padding-bottom: 2.5rem;
+  --gs-item-margin-top: 10px;
+  --gs-item-margin-bottom: 10px;
+  --gs-item-margin-left: 0px;
+  --gs-item-margin-right: 0px;
 }
 
 #fab button {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -32,8 +32,8 @@ function attachGridEvents(g) {
 
 const grid = GridStack.init(
   {
-    // standard gap between widgets as in the GridStack demo
-    margin: 10,
+    // vertical gap between widgets (horizontal spacing handled by CSS)
+    margin: "10px 0",
     column: 12,
     float: false,
     resizable: { handles: "e, se, s, w" },


### PR DESCRIPTION
## Summary
- adjust grid CSS variables to control vertical gap
- set vertical margin in grid initialization

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856f876ab00832898adf2e3864f9a76