### PR TITLE
Fix grid spacing by updating GridStack CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>FastNotes</title>
 
-  <link href="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/gridstack@9.5.1/dist/gridstack.min.css" rel="stylesheet" />
   <!-- required for custom column layouts (below 12 columns) -->
-  <link href="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-extra.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/gridstack@9.5.1/dist/gridstack-extra.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="/src/css/main.css" />
   <link rel="manifest" href="/manifest.json" />
   <script type="module" src="/src/js/app.js"></script>


### PR DESCRIPTION
## Summary
- use GridStack 9.5.1 CSS to match JS version

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685700c071ac83288e3f2116ccebb5d2