### PR TITLE
Remove move in/out buttons

### DIFF
--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -8,8 +8,6 @@ export const PT = {
   toggle: "Alternar",
   addCard: "Adicionar card",
   delete: "Excluir",
-  moveOut: "Enviar para tela principal",
-  moveIn: "Mover para container",
   selectContainer: "Escolha o container (id)",
 };
 
@@ -23,8 +21,6 @@ export const EN = {
   toggle: "Toggle",
   addCard: "Add card",
   delete: "Delete",
-  moveOut: "Move out",
-  moveIn: "Move into container",
   selectContainer: "Choose container (id)",
 };
 

--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -21,8 +21,6 @@ export function create(data = {}) {
       <div class="card-actions">
         <button class="lock" aria-label="Lock">🔒</button>
         <button class="copy" aria-label="Copy">📄</button>
-        <button class="move-in" aria-label="Move in">↘</button>
-        <button class="move-out" aria-label="Move out">↗</button>
         <button class="delete" aria-label="Delete">🗑️</button>
         <input class="color" type="color" aria-label="Color" value="${item.color}">
       </div>
@@ -36,16 +34,12 @@ export function create(data = {}) {
   const colorEl = content.querySelector("input.color");
   const lockBtn = content.querySelector("button.lock");
   const copyBtn = content.querySelector("button.copy");
-  const moveInBtn = content.querySelector("button.move-in");
-  const moveOutBtn = content.querySelector("button.move-out");
   const delBtn = content.querySelector("button.delete");
   titleEl.textContent = item.title;
   textEl.value = item.text;
   colorEl.value = item.color;
   lockBtn.setAttribute("aria-label", t("lock"));
   copyBtn.setAttribute("aria-label", t("copy"));
-  moveInBtn.setAttribute("aria-label", t("moveIn"));
-  moveOutBtn.setAttribute("aria-label", t("moveOut"));
   applyColor(item.color);
   setLock(item.locked);
 
@@ -65,12 +59,6 @@ export function create(data = {}) {
     const locked = wrapper.dataset.locked === "true";
     setLock(!locked);
     Store.patch(id, { locked: wrapper.dataset.locked === "true" });
-  });
-  moveInBtn.addEventListener("click", () => {
-    wrapper.dispatchEvent(new CustomEvent("movein", { bubbles: true }));
-  });
-  moveOutBtn.addEventListener("click", () => {
-    wrapper.dispatchEvent(new CustomEvent("moveout", { bubbles: true }));
   });
   content.querySelector("button.copy").addEventListener("click", () => {
     navigator.clipboard.writeText(textEl.value);


### PR DESCRIPTION
## Summary
- remove `move-in` and `move-out` card buttons
- delete unused translation keys

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685702c40d688328a518c59ac70918bb