### PR TITLE
Add sidebar menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,15 @@
   <script type="module" src="/src/js/app.js"></script>
 </head>
 <body>
-  <div id="menu">
+  <button id="menu-toggle" aria-label="Menu">☰</button>
+  <div id="sidebar-overlay"></div>
+  <aside id="sidebar">
+    <h2>FastNotes</h2>
     <button id="btn-export" aria-label="Exportar">Export</button>
     <button id="btn-import" aria-label="Importar">Import</button>
     <input type="file" id="import-file" accept=".fastnotes.json" hidden>
-  </div>
-  <button id="auth-btn">Login</button>
+    <button id="auth-btn">Login</button>
+  </aside>
 
   <div id="fab" class="fab">
     <button id="fab-main" aria-label="Adicionar" class="fab-main">+</button>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -12,15 +12,51 @@ body {
   z-index: 200;
 }
 
-#menu {
+#sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 260px;
+  max-width: 80%;
+  background: #fff;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.2);
+  padding: 1rem;
+  transform: translateX(-100%);
+  transition: transform 0.3s;
+  z-index: 300;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+#sidebar.open {
+  transform: translateX(0);
+}
+#sidebar button {
+  border: none;
+  background: #eee;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+#sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s;
+  z-index: 250;
+}
+#sidebar-overlay.show {
+  opacity: 1;
+  visibility: visible;
+}
+#menu-toggle {
   position: fixed;
   left: 1rem;
   top: 1rem;
-  display: flex;
-  gap: 0.5rem;
-  z-index: 200;
-}
-#menu button {
+  z-index: 310;
   border: none;
   background: #eee;
   padding: 0.25rem 0.5rem;
@@ -244,15 +280,12 @@ body {
 }
 
 #auth-btn {
-  position: fixed;
-  right: 2rem;
-  top: 2rem;
   padding: 0.5rem 1rem;
   border: none;
   border-radius: 4px;
   background: #28a745;
   color: #fff;
-  z-index: 200;
+  cursor: pointer;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -51,6 +51,12 @@ const fabMain = document.getElementById("fab-main");
 const fabCard = document.getElementById("fab-card");
 const fabContainerBtn = document.getElementById("fab-container");
 const fabFolderBtn = document.getElementById("fab-folder");
+const sidebar = document.getElementById("sidebar");
+const sidebarOverlay = document.getElementById("sidebar-overlay");
+const menuToggle = document.getElementById("menu-toggle");
+
+menuToggle.addEventListener("click", () => openSidebar(true));
+sidebarOverlay.addEventListener("click", () => openSidebar(false));
 
 fabMain.addEventListener("click", toggleMenu);
 fabCard.addEventListener("click", () => {
@@ -66,10 +72,14 @@ fabFolderBtn.addEventListener("click", () => {
   toggleMenu(false);
 });
 document.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") toggleMenu(false);
+  if (e.key === "Escape") {
+    toggleMenu(false);
+    openSidebar(false);
+  }
 });
 
 toggleMenu(false);
+openSidebar(false);
 
 document.getElementById("fab-add")?.addEventListener("click", addCard);
 document
@@ -112,6 +122,11 @@ function toggleMenu(force) {
     (btn) => (btn.disabled = !open),
   );
   if (open) fabCard.focus();
+}
+
+function openSidebar(open = true) {
+  sidebar.classList.toggle("open", open);
+  sidebarOverlay.classList.toggle("show", open);
 }
 
 function addCard(data = {}, g = grid, parent = "root") {


### PR DESCRIPTION
## Summary
- add a sliding sidebar with system actions
- style sidebar, overlay and login button
- hook up sidebar toggle logic in app.js

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685709a833d08328826b406276609030