### PR TITLE
Add card creation inside folders

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -248,6 +248,11 @@ body {
   flex: 1;
   resize: vertical;
 }
+.folder-header .folder-add {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
 .folder-overlay {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- enable adding cards within folder overlays
- style folder add button

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68570d76de5c8328bc39161121601ffd