### PR TITLE
Re-enable folder opening on card click

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -241,6 +241,7 @@ body {
   justify-content: center;
   text-align: center;
   gap: 0.25rem;
+  cursor: pointer;
 }
 .folder-card h6 {
   margin: 0;

--- a/src/js/ui/folder.js
+++ b/src/js/ui/folder.js
@@ -22,11 +22,10 @@ export function create(data = {}) {
     </div>
   `;
   const content = wrapper.firstElementChild;
-  const icon = content.querySelector('.folder-icon');
   const nameEl = content.querySelector('.folder-name');
   nameEl.textContent = item.title;
 
-  icon.addEventListener('click', openFolder);
+  content.addEventListener('click', openFolder);
 
   function openFolder() {
     if (document.querySelector('.folder-overlay')) return;


### PR DESCRIPTION
## Summary
- allow clicking the entire folder card to open the folder overlay
- show pointer cursor over folder cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857121ac39c8328bbf1c719f5a41073