### PR TITLE
Change add card icons

### DIFF
--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -27,7 +27,7 @@ export function create(data = {}) {
         <button class="toggle" aria-label="${t("toggle")}">▾</button>
         <span class="lock-indicator" style="display:none">🔒</span>
         <h6 contenteditable="true"></h6>
-        <button class="add-card" aria-label="${t("addCard")}">+</button>
+        <button class="add-card" aria-label="${t("addCard")}">➕</button>
         <button class="delete" aria-label="${t("delete")}">🗑️</button>
       </div>
       <div class="container-body">

--- a/src/js/ui/folder.js
+++ b/src/js/ui/folder.js
@@ -35,7 +35,7 @@ export function create(data = {}) {
       <div class="folder-header">
         <button class="folder-back" aria-label="Back">\u2190</button>
         <h6 class="folder-title" contenteditable="true"></h6>
-        <button class="folder-add" aria-label="${t('addCard')}">+</button>
+        <button class="folder-add" aria-label="${t('addCard')}">➕</button>
         <textarea class="folder-desc" rows="2"></textarea>
       </div>
       <div class="grid-stack folder-grid"></div>


### PR DESCRIPTION
## Summary
- restyle add-card buttons using `➕` emoji

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685713beb5788328b7616861841b4317