### PR TITLE
Enforce 20 char title limit

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -1,0 +1,1 @@
+export const TITLE_MAX_LENGTH = 20;

--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -1,5 +1,6 @@
 import * as Store from "../store.js";
 import { t } from "../i18n.js";
+import { TITLE_MAX_LENGTH } from "../constants.js";
 
 export function create(data = {}) {
   const item = {
@@ -44,7 +45,9 @@ export function create(data = {}) {
   setLock(item.locked);
 
   titleEl.addEventListener("input", () => {
-    Store.patch(id, { title: titleEl.textContent });
+    const text = titleEl.textContent.slice(0, TITLE_MAX_LENGTH);
+    if (text !== titleEl.textContent) titleEl.textContent = text;
+    Store.patch(id, { title: text });
   });
   textEl.addEventListener("input", () => {
     Store.patch(id, { text: textEl.value });

--- a/src/js/ui/container.js
+++ b/src/js/ui/container.js
@@ -2,6 +2,7 @@ import { GridStack } from "gridstack";
 import * as Store from "../store.js";
 import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
+import { TITLE_MAX_LENGTH } from "../constants.js";
 
 export function create(data = {}) {
   const item = {
@@ -48,8 +49,10 @@ export function create(data = {}) {
 
   titleEl.textContent = item.title;
   titleEl.addEventListener("input", () => {
-    item.title = titleEl.textContent;
-    Store.patch(id, { title: item.title });
+    const text = titleEl.textContent.slice(0, TITLE_MAX_LENGTH);
+    if (text !== titleEl.textContent) titleEl.textContent = text;
+    item.title = text;
+    Store.patch(id, { title: text });
   });
 
   const subgrid = GridStack.init(

--- a/src/js/ui/folder.js
+++ b/src/js/ui/folder.js
@@ -2,6 +2,7 @@ import { GridStack } from "gridstack";
 import * as Store from "../store.js";
 import { create as createCard } from "./card.js";
 import { t } from "../i18n.js";
+import { TITLE_MAX_LENGTH } from "../constants.js";
 
 export function create(data = {}) {
   const item = {
@@ -109,9 +110,11 @@ export function create(data = {}) {
     titleEl.textContent = item.title;
     descEl.value = item.desc;
     titleEl.addEventListener("input", () => {
-      item.title = titleEl.textContent;
-      nameEl.textContent = item.title;
-      Store.patch(id, { title: item.title });
+      const text = titleEl.textContent.slice(0, TITLE_MAX_LENGTH);
+      if (text !== titleEl.textContent) titleEl.textContent = text;
+      item.title = text;
+      nameEl.textContent = text;
+      Store.patch(id, { title: text });
     });
     descEl.addEventListener("input", () => {
       item.desc = descEl.value;


### PR DESCRIPTION
## Summary
- add `TITLE_MAX_LENGTH` constant
- limit title length for cards, containers and folders

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68572e806480832886f4273fae27622f