### PR TITLE
Fix PWA manifest configuration

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,15 @@
 import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import fs from 'fs'
+
+const manifest = JSON.parse(fs.readFileSync('./public/manifest.webmanifest', 'utf-8'))
 
 export default defineConfig({
   base: './',
   plugins: [
     VitePWA({
       registerType: 'autoUpdate',
-      manifest: 'public/manifest.webmanifest',
+      manifest,
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         runtimeCaching: [


### PR DESCRIPTION
## Summary
- correctly load manifest JSON in vite config

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685beddf39408328962e88694c980142