### PR TITLE
Fix service worker registration

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -359,7 +359,7 @@ async function start() {
 start();
 
 if ("serviceWorker" in navigator) {
-  const wb = new Workbox("/sw.js", { type: "module" });
+  const wb = new Workbox("/sw.js");
 
   wb.addEventListener("installed", ({ isUpdate }) => {
     if (isUpdate)


### PR DESCRIPTION
## Summary
- remove `type: "module"` when registering Workbox service worker

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c069b72908328abaa7c5d984c1981